### PR TITLE
Add CPU-aware build optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # LPM.Org
 The Linux Package Manager
+
+## Optimization
+
+`lpm` can optimize builds based on your CPU and the selected optimization
+level. The `/etc/lpm/lpm.conf` file accepts an `OPT_LEVEL` entry (`-Os`,
+`-O2`, `-O3`, or `-Ofast`). During package builds the manager detects the CPU
+family and automatically sets `-march`/`-mtune` along with the configured
+optimization level for `CFLAGS`, `CXXFLAGS`, and `LDFLAGS`.


### PR DESCRIPTION
## Summary
- detect CPU vendor/family and derive -march/-mtune for builds
- allow configuring optimization level via OPT_LEVEL in lpm.conf
- apply detected flags to CFLAGS, CXXFLAGS, and LDFLAGS and document feature

## Testing
- `python lpm.py --help`

------
https://chatgpt.com/codex/tasks/task_e_68c4d8cbcae883279f51816c65e6a761