### PR TITLE
Respect lpmbuild CFLAGS and set default build flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,7 @@ The Linux Package Manager
 `lpm` can optimize builds based on your CPU and the selected optimization
 level. The `/etc/lpm/lpm.conf` file accepts an `OPT_LEVEL` entry (`-Os`,
 `-O2`, `-O3`, or `-Ofast`). During package builds the manager detects the CPU
-family and automatically sets `-march`/`-mtune` along with the configured
-optimization level for `CFLAGS`, `CXXFLAGS`, and `LDFLAGS`.
+family and automatically sets `-march`/`-mtune` along with `-pipe` and
+`-fPIC` plus the configured optimization level for `CFLAGS` and `CXXFLAGS`
+while `LDFLAGS` uses only the optimization level. Any `CFLAGS` defined in a
+`.lpmbuild` script are appended to the defaults.

--- a/lpm.py
+++ b/lpm.py
@@ -1235,7 +1235,7 @@ _emit_array() {{
     printf "\\n"
   fi
 }}
-for v in NAME VERSION RELEASE ARCH SUMMARY URL LICENSE; do _emit_scalar "$v"; done
+for v in NAME VERSION RELEASE ARCH SUMMARY URL LICENSE CFLAGS; do _emit_scalar "$v"; done
 for a in REQUIRES PROVIDES CONFLICTS OBSOLETES RECOMMENDS SUGGESTS; do _emit_array "$a"; done
 """
 
@@ -1393,7 +1393,9 @@ def run_lpmbuild(script: Path, outdir: Optional[Path]=None) -> Path:
         "SRCROOT": str(srcroot),
     })
 
-    flags = f"{OPT_LEVEL} -march={MARCH} -mtune={MTUNE}"
+    base_flags = f"{OPT_LEVEL} -march={MARCH} -mtune={MTUNE} -pipe -fPIC"
+    extra_cflags = " ".join(filter(None, [env.get("CFLAGS", "").strip(), scal.get("CFLAGS", "").strip()]))
+    flags = f"{base_flags} {extra_cflags}".strip()
     env["CFLAGS"] = flags
     env["CXXFLAGS"] = flags
     env["LDFLAGS"] = OPT_LEVEL


### PR DESCRIPTION
## Summary
- include any CFLAGS from a `.lpmbuild` script when building packages
- default to using `-pipe -fPIC` alongside CPU-optimized flags
- document the new flag behavior

## Testing
- `python -m py_compile lpm.py`
- `python lpm.py --help`

------
https://chatgpt.com/codex/tasks/task_e_68c4da8209148327970681a66a865ca7