### PR TITLE
Add configurable snapshot pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,10 @@ family and automatically sets `-march`/`-mtune` along with `-pipe` and
 `-fPIC` plus the configured optimization level for `CFLAGS` and `CXXFLAGS`
 while `LDFLAGS` uses only the optimization level. Any `CFLAGS` defined in a
 `.lpmbuild` script are appended to the defaults.
+
+## Snapshots
+LPM stores filesystem snapshots in `/var/lib/lpm/snapshots`. Configure
+`MAX_SNAPSHOTS` in `/etc/lpm/lpm.conf` to limit how many snapshots are kept
+(default `10`). Older entries beyond the limit are automatically pruned after
+creating a new snapshot. You can trigger cleanup manually with
+`lpm snapshots --prune`.


### PR DESCRIPTION
## Summary
- allow configuring MAX_SNAPSHOTS in lpm.conf
- automatically prune old snapshots and expose `lpm snapshots --prune`

## Testing
- `python -m py_compile lpm.py`
- `python lpm.py snapshots --help`
- `python lpm.py snapshots --prune`


------
https://chatgpt.com/codex/tasks/task_e_68c4df4f24b88327a7b3952cbe9a5c51