### PR TITLE
Add kernel metadata and install hook

### DIFF
--- a/usr/share/lpm/hooks/kernel_install
+++ b/usr/share/lpm/hooks/kernel_install
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+preset="${LPM_PRESET:-default}"
+mkinitcpio -p "$preset"
+
+# Bootloader regeneration hooks
+if command -v bootctl >/dev/null 2>&1; then
+    bootctl update || true
+fi
+if command -v grub-mkconfig >/dev/null 2>&1; then
+    grub-mkconfig -o /boot/grub/grub.cfg || true
+fi


### PR DESCRIPTION
## Summary
- allow `.lpmbuild` to mark kernel packages and optional mkinitcpio preset
- run kernel install hook after installing/upgrading kernel packages
- provide default `kernel_install` hook and allow `hook.d` directory scripts

## Testing
- `python -m py_compile lpm.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4e5aaf2408327b3e9b284321fbac2