### PR TITLE
docs: add bootstrap section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ LPM stores filesystem snapshots in `/var/lib/lpm/snapshots`. Configure
 (default `10`). Older entries beyond the limit are automatically pruned after
 creating a new snapshot. You can trigger cleanup manually with
 `lpm snapshots --prune`.
+
+## Bootstrap
+
+Run `lpm bootstrap /path/to/root --include vim openssh` to create a chroot-ready
+filesystem tree with verified packages.


### PR DESCRIPTION
## Summary
- document `lpm bootstrap /path/to/root --include vim openssh`
- note that bootstrap creates a chroot-ready tree with verified packages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4ffb961c08327a2b7298a00765b26