### PR TITLE
Implement implication graph with clause database reduction

### DIFF
--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from lpm import CNF, cdcl_solve
+
+
+def test_conflicting_packages_unsat():
+    cnf = CNF()
+    a = cnf.new_var('A')
+    b = cnf.new_var('B')
+    c = cnf.new_var('C')
+    # A -> B
+    cnf.add_clause([-a, b])
+    # B conflicts with C
+    cnf.add_clause([-b, -c])
+    # require A and C simultaneously
+    cnf.add_clause([a])
+    cnf.add_clause([c])
+    res = cdcl_solve(cnf, set(), set())
+    assert not res.sat
+
+
+def test_dependency_resolution():
+    cnf = CNF()
+    a = cnf.new_var('A')
+    b = cnf.new_var('B')
+    c = cnf.new_var('C')
+    # A -> (B or C)
+    cnf.add_clause([-a, b, c])
+    # B conflicts C
+    cnf.add_clause([-b, -c])
+    cnf.add_clause([a])
+    res = cdcl_solve(cnf, set(), set())
+    assert res.sat
+    assert res.assign[a]
+    # exactly one of b or c is installed
+    assert res.assign[b] ^ res.assign[c]


### PR DESCRIPTION
## Summary
- track clause activity and maintain implication graph nodes for each assignment
- perform conflict analysis via graph to learn clauses and backjump
- periodically prune low-activity learnt clauses and add regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c50762f8bc83278a9cecb655545d17