### PR TITLE
Introduce reusable CDCL solver with assumption support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,26 @@ fields to entries in `repos.json`.
 A small benchmark harness is provided at `benchmarks/solver_bench.py`. Run
 `python benchmarks/solver_bench.py` to measure resolution speed with the default
 tuning.
+
+## SAT Solver API
+
+The SAT solver can be reused across multiple solves while retaining learned
+clauses and variable activity. Instantiate `CDCLSolver` with a `CNF` instance
+and call `solve()` with an optional list of assumed literals:
+
+```python
+from src import CNF, CDCLSolver
+
+cnf = CNF()
+v1 = cnf.new_var("A")
+v2 = cnf.new_var("B")
+cnf.add_clause([v1, v2])
+cnf.add_clause([-v1, v2])
+
+solver = CDCLSolver(cnf)
+result = solver.solve([])          # solve normally
+result_with_assump = solver.solve([v1])  # assume A is true temporarily
+```
+
+Subsequent calls to `solve()` reuse variable activity and learned clauses
+accumulated from previous runs, enabling efficient incremental solving.

--- a/benchmarks/solver_bench.py
+++ b/benchmarks/solver_bench.py
@@ -19,8 +19,8 @@ def run():
     for size in (50, 100, 150):
         cnf = chain(size)
         start = time.time()
-        solver = CDCLSolver()
-        solver.solve(cnf, set(), set())
+        solver = CDCLSolver(cnf)
+        solver.solve([])
         dur = time.time() - start
         print(f"chain {size}: {dur:.4f}s")
 

--- a/lpm.py
+++ b/lpm.py
@@ -26,7 +26,7 @@ import zstandard as zstd
 
 from src.config import *  # noqa: F401,F403
 from src.fs import read_json, write_json, urlread
-from src.solver import CNF, CDCLSolver, cdcl_solve
+from src.solver import CNF, CDCLSolver
 
 # =========================== Protected packages ===============================
 PROTECTED_FILE = Path("/etc/lpm/protected.json")
@@ -525,7 +525,8 @@ def encode_resolution(u: Universe, goals: List[DepExpr]) -> Tuple[CNF, Dict[Tupl
 def solve(goals: List[str], universe: Universe) -> List[PkgMeta]:
     goal_exprs = [parse_dep_expr(s) for s in goals]
     cnf, var_of, ptrue, pfalse, bias_map, decay_map = encode_resolution(universe, goal_exprs)
-    res = cdcl_solve(cnf, ptrue, pfalse, bias_map, decay_map)
+    solver = CDCLSolver(cnf, ptrue, pfalse, bias_map, decay_map)
+    res = solver.solve([])
     if not res.sat: raise RuntimeError("Unsatisfiable dependency set")
     inv: Dict[int,Tuple[str,str]] = {v:k for k,v in var_of.items()}
     chosen: Dict[str,PkgMeta] = {}

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,9 +1,8 @@
-from .solver import CNF, SATResult, Implication, CDCLSolver, cdcl_solve
+from .solver import CNF, SATResult, Implication, CDCLSolver
 
 __all__ = [
     "CNF",
     "SATResult",
     "Implication",
     "CDCLSolver",
-    "cdcl_solve",
 ]

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -18,8 +18,8 @@ def test_conflicting_packages_unsat():
     # require A and C simultaneously
     cnf.add_clause([a])
     cnf.add_clause([c])
-    solver = CDCLSolver()
-    res = solver.solve(cnf, set(), set())
+    solver = CDCLSolver(cnf)
+    res = solver.solve([])
     assert not res.sat
 
 
@@ -33,8 +33,8 @@ def test_dependency_resolution():
     # B conflicts C
     cnf.add_clause([-b, -c])
     cnf.add_clause([a])
-    solver = CDCLSolver()
-    res = solver.solve(cnf, set(), set())
+    solver = CDCLSolver(cnf)
+    res = solver.solve([])
     assert res.sat
     assert res.assign[a]
     # exactly one of b or c is installed


### PR DESCRIPTION
## Summary
- Refactor SAT solving into a reusable `CDCLSolver` that maintains clause and variable activity across solves
- Add assumption-driven solving and update resolver, benchmarks, and tests to use the new API
- Document how to reuse the solver and pass assumptions in `README.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c50c99737883279cacf9352614eb60