### PR TITLE
Expose unsat core from SAT solver

### DIFF
--- a/lpm.py
+++ b/lpm.py
@@ -527,8 +527,10 @@ def solve(goals: List[str], universe: Universe) -> List[PkgMeta]:
     cnf, var_of, ptrue, pfalse, bias_map, decay_map = encode_resolution(universe, goal_exprs)
     solver = CDCLSolver(cnf, ptrue, pfalse, bias_map, decay_map)
     res = solver.solve([])
-    if not res.sat: raise RuntimeError("Unsatisfiable dependency set")
     inv: Dict[int,Tuple[str,str]] = {v:k for k,v in var_of.items()}
+    if not res.sat:
+        names = sorted({inv.get(abs(l))[0] for l in (res.unsat_core or []) if abs(l) in inv})
+        raise RuntimeError("Unsatisfiable dependency set involving: " + ", ".join(names))
     chosen: Dict[str,PkgMeta] = {}
     for vid,val in res.assign.items():
         if not val: continue

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -21,6 +21,8 @@ def test_conflicting_packages_unsat():
     solver = CDCLSolver(cnf)
     res = solver.solve([])
     assert not res.sat
+    core_names = sorted(cnf.varname[abs(l)] for l in res.unsat_core)
+    assert core_names == ["A", "C"]
 
 
 def test_dependency_resolution():


### PR DESCRIPTION
## Summary
- Extend `SATResult` with optional `unsat_core` field and compute the core clause on unsatisfiable instances
- Surface conflicting package names via CLI when dependency resolution is unsatisfiable
- Add regression test verifying the core identifies conflicting packages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c50dc8491c832795a911533707e656