### PR TITLE
refactor: initialize state lazily

### DIFF
--- a/lpm.py
+++ b/lpm.py
@@ -25,6 +25,7 @@ from collections import deque
 import zstandard as zstd
 
 from src.config import *  # noqa: F401,F403
+initialize_state()
 from src.fs import read_json, write_json, urlread
 from src.solver import CNF, CDCLSolver
 

--- a/src/config.py
+++ b/src/config.py
@@ -19,13 +19,16 @@ SIGN_KEY  = Path("/etc/lpm/private/lpm_signing.pem")   # OpenSSL PEM private key
 TRUST_DIR = Path("/etc/lpm/trust")                     # dir of *.pem public keys for verification
 DEFAULT_ROOT = "/"
 UMASK = 0o22
-os.umask(UMASK)
-for d in (STATE_DIR, CACHE_DIR, SNAPSHOT_DIR):
-    d.mkdir(parents=True, exist_ok=True)
-if not REPO_LIST.exists():
-    REPO_LIST.write_text("[]", encoding="utf-8")
-if not PIN_FILE.exists():
-    PIN_FILE.write_text(json.dumps({"hold": [], "prefer": {}}, indent=2), encoding="utf-8")
+
+
+def initialize_state() -> None:
+    os.umask(UMASK)
+    for d in (STATE_DIR, CACHE_DIR, SNAPSHOT_DIR):
+        d.mkdir(parents=True, exist_ok=True)
+    if not REPO_LIST.exists():
+        REPO_LIST.write_text("[]", encoding="utf-8")
+    if not PIN_FILE.exists():
+        PIN_FILE.write_text(json.dumps({"hold": [], "prefer": {}}, indent=2), encoding="utf-8")
 
 
 def load_conf(path: Path) -> Dict[str, str]:
@@ -129,6 +132,7 @@ __all__ = [
     "TRUST_DIR",
     "DEFAULT_ROOT",
     "UMASK",
+    "initialize_state",
     "load_conf",
     "CONF",
     "ARCH",


### PR DESCRIPTION
## Summary
- extract config directory setup into `initialize_state`
- call `initialize_state` in `lpm.py` to avoid import side effects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c51473d88483279dfb0c04e83fcf05