### PR TITLE
Handle dependency resolution failures gracefully

### DIFF
--- a/tests/test_resolution_error.py
+++ b/tests/test_resolution_error.py
@@ -1,0 +1,8 @@
+import pytest
+from lpm import solve, Universe, ResolutionError
+
+
+def test_solve_raises_resolution_error_for_missing_provider():
+    u = Universe({}, {}, {}, {}, set())
+    with pytest.raises(ResolutionError):
+        solve(["nonexistent"], u)


### PR DESCRIPTION
## Summary
- add `ResolutionError` for dependency resolution failures
- raise `ResolutionError` instead of exiting in solver
- handle `ResolutionError` in CLI and add test coverage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c51c9a50a883278dce51a1f2fb36b9