### PR TITLE
Track exported symbols in package metadata

### DIFF
--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -1,0 +1,18 @@
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from lpm import collect_manifest
+
+
+def test_collect_manifest_captures_exported_symbols(tmp_path):
+    src = tmp_path / "foo.c"
+    src.write_text("int foo() { return 42; }\n")
+    so = tmp_path / "libfoo.so"
+    subprocess.run(["gcc", "-shared", "-fPIC", str(src), "-o", str(so)], check=True)
+    mani = collect_manifest(tmp_path)
+    entry = next(e for e in mani if e["path"] == "/libfoo.so")
+    assert "symbols" in entry
+    assert "foo" in entry["symbols"]


### PR DESCRIPTION
## Summary
- capture exported ELF symbols when building package manifests
- persist captured symbols in the installed package database
- test manifest symbol extraction for shared libraries

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c529e28bb483279f8e68cb2970f432