### PR TITLE
feat: add flag to skip buildpkg dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ arguments and optional flags.
   [--provides PKG ...] [--conflicts PKG ...] [--obsoletes PKG ...]
   [--recommends PKG ...] [--suggests PKG ...] [--output FILE] [--no-sign]`
   – build an `.lpm` package from a staged root.
-- `lpm buildpkg SCRIPT [--outdir PATH]` – run a `.lpmbuild` script to produce a
-  package.
+- `lpm buildpkg SCRIPT [--outdir PATH] [--no-deps]` – run a `.lpmbuild` script to
+  produce a package.
 - `lpm genindex REPO_DIR [--base-url URL] [--arch ARCH]` – generate an
   `index.json` for a directory of packages.
 - `lpm installpkg FILE... [--root PATH] [--dry-run] [--verify] [--force]`

--- a/tests/test_buildpkg_no_deps.py
+++ b/tests/test_buildpkg_no_deps.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import subprocess
+import textwrap
+from pathlib import Path
+
+def test_buildpkg_no_deps_skips_dependency_build(tmp_path):
+    script = tmp_path / "foo.lpmbuild"
+    script.write_text(
+        textwrap.dedent(
+            """
+            NAME=foo
+            VERSION=1
+            RELEASE=1
+            ARCH=noarch
+            REQUIRES=(nonexistent-dep)
+            prepare() { :; }
+            build() { :; }
+            install() {
+                mkdir -p "$pkgdir"
+                echo hi > "$pkgdir/hi"
+            }
+            """
+        )
+    )
+
+    env = os.environ.copy()
+    env["LPM_STATE_DIR"] = str(tmp_path / "state")
+
+    lpm = Path(__file__).resolve().parent.parent / "lpm.py"
+
+    # Without --no-deps the build should fail trying to fetch the missing dep
+    result = subprocess.run(
+        [sys.executable, str(lpm), "buildpkg", str(script)],
+        env=env,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        input="\n",
+    )
+    assert result.returncode != 0
+
+    # With --no-deps the build should succeed and produce a package
+    result = subprocess.run(
+        [sys.executable, str(lpm), "buildpkg", str(script), "--no-deps"],
+        env=env,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        input="\n",
+    )
+    assert result.returncode == 0, result.stderr
+    assert any(tmp_path.glob("*.zst"))


### PR DESCRIPTION
## Summary
- allow `lpm buildpkg` to skip building dependencies with `--no-deps`
- gate dependency auto-build in `run_lpmbuild` with a `build_deps` flag
- document new flag and cover with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5aea44b508327ac754389c2ac60b3