### PR TITLE
Support Python hook scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ creating a new snapshot. You can trigger cleanup manually with
 Run `lpm bootstrap /path/to/root --include vim openssh` to create a
 chroot‑ready filesystem tree with verified packages.
 
+## Hooks
+
+Hook scripts placed in `/usr/share/lpm/hooks` or within `<hook>.d` directories
+run at key points during package operations. These hooks may be either shell or
+Python scripts, with Python hooks executed using the current Python interpreter.
+
 ## Solver heuristics
 
 The resolver uses a CDCL SAT solver with VSIDS‑style variable scoring and phase

--- a/lpm.py
+++ b/lpm.py
@@ -640,14 +640,20 @@ def solve(goals: List[str], universe: Universe) -> List[PkgMeta]:
 # =========================== Hooks =============================================
 def run_hook(hook: str, env: Dict[str,str]):
     path = HOOK_DIR / hook
-    if path.exists() and os.access(path, os.X_OK):
-        subprocess.run([str(path)], env={**os.environ, **env}, check=True)
+    if path.exists():
+        if path.suffix == ".py":
+            subprocess.run([sys.executable, str(path)], env={**os.environ, **env}, check=True)
+        elif os.access(path, os.X_OK):
+            subprocess.run([str(path)], env={**os.environ, **env}, check=True)
 
     dpath = HOOK_DIR / f"{hook}.d"
     if dpath.is_dir():
         for script in sorted(dpath.iterdir()):
-            if script.is_file() and os.access(script, os.X_OK):
-                subprocess.run([str(script)], env={**os.environ, **env}, check=True)
+            if script.is_file():
+                if script.suffix == ".py":
+                    subprocess.run([sys.executable, str(script)], env={**os.environ, **env}, check=True)
+                elif os.access(script, os.X_OK):
+                    subprocess.run([str(script)], env={**os.environ, **env}, check=True)
         
 # =========================== Service File Handling =============================
 def handle_service_files(pkg_name: str, root: Path):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,17 @@
+import lpm
+
+
+def test_python_hook(tmp_path, monkeypatch):
+    hook_dir = tmp_path / "hooks"
+    hook_dir.mkdir()
+    monkeypatch.setattr(lpm, "HOOK_DIR", hook_dir)
+
+    d = hook_dir / "sample.d"
+    d.mkdir()
+    marker = hook_dir / "ran"
+    script = d / "hook.py"
+    script.write_text(f"open({repr(str(marker))}, 'w').write('ok')")
+
+    lpm.run_hook("sample", {})
+
+    assert marker.read_text() == "ok"


### PR DESCRIPTION
## Summary
- run Python hook files via current interpreter
- document that hooks can be shell or Python
- test Python hook execution

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5b536821c8327b2ea5dddd2d9cb9d