### PR TITLE
Add post-install hooks for cache updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,19 @@ Hook scripts placed in `/usr/share/lpm/hooks` or within `<hook>.d` directories
 run at key points during package operations. These hooks may be either shell or
 Python scripts, with Python hooks executed using the current Python interpreter.
 
+### Default post-install hooks
+
+LPM ships with several hooks that run after a package is installed:
+
+- `010-ldconfig.py` – runs `ldconfig` when installing into the real root (`/`).
+- `020-update-desktop-database.py` – refreshes the desktop file database if
+  `update-desktop-database` is available.
+- `030-update-icon-cache.py` – updates icon caches for themes in
+  `/usr/share/icons` using `gtk-update-icon-cache`.
+
+Each hook checks for the presence of its corresponding tool and exits quietly
+if it is not installed.
+
 ## Solver heuristics
 
 The resolver uses a CDCL SAT solver with VSIDS‑style variable scoring and phase

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,3 +1,9 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
 import lpm
 
 
@@ -15,3 +21,51 @@ def test_python_hook(tmp_path, monkeypatch):
     lpm.run_hook("sample", {})
 
     assert marker.read_text() == "ok"
+
+
+def test_post_install_hooks_run(tmp_path, monkeypatch):
+    root = tmp_path / "root"
+    (root / "usr/share/icons/hicolor").mkdir(parents=True)
+    (root / "usr/share/icons/hicolor/index.theme").write_text("[Icon Theme]")
+    (root / "usr/share/applications").mkdir(parents=True)
+    (root / "usr/share/applications/foo.desktop").write_text("[Desktop Entry]")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "log"
+    for name in ("update-desktop-database", "gtk-update-icon-cache", "ldconfig"):
+        p = bin_dir / name
+        p.write_text(f"#!/bin/sh\necho {name} >> {log}\n")
+        p.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+
+    hook_dir = Path(__file__).resolve().parent.parent / "usr/share/lpm/hooks"
+    monkeypatch.setattr(lpm, "HOOK_DIR", hook_dir)
+
+    lpm.run_hook("post_install", {"LPM_ROOT": str(root)})
+
+    calls = log.read_text().splitlines()
+    assert "update-desktop-database" in calls
+    assert "gtk-update-icon-cache" in calls
+    assert "ldconfig" not in calls
+
+
+def test_ldconfig_only_for_real_root(tmp_path, monkeypatch):
+    hook_dir = Path(__file__).resolve().parent.parent / "usr/share/lpm/hooks"
+    monkeypatch.setattr(lpm, "HOOK_DIR", hook_dir)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "log"
+    for name in ("ldconfig", "update-desktop-database", "gtk-update-icon-cache"):
+        p = bin_dir / name
+        p.write_text(f"#!/bin/sh\necho {name} >> {log}\n")
+        p.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+
+    lpm.run_hook("post_install", {"LPM_ROOT": "/"})
+    assert "ldconfig" in log.read_text().splitlines()
+
+    log.write_text("")
+    lpm.run_hook("post_install", {"LPM_ROOT": str(tmp_path)})
+    assert "ldconfig" not in log.read_text().splitlines()

--- a/usr/share/lpm/hooks/post_install.d/010-ldconfig.py
+++ b/usr/share/lpm/hooks/post_install.d/010-ldconfig.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+import os
+import shutil
+import subprocess
+
+
+def main():
+    # Only run ldconfig when installing to the real root
+    if os.environ.get("LPM_ROOT", "/") != "/":
+        return
+    tool = shutil.which("ldconfig")
+    if not tool:
+        return
+    subprocess.run([tool], check=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/usr/share/lpm/hooks/post_install.d/020-update-desktop-database.py
+++ b/usr/share/lpm/hooks/post_install.d/020-update-desktop-database.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def main():
+    tool = shutil.which("update-desktop-database")
+    if not tool:
+        return
+    root = Path(os.environ.get("LPM_ROOT", "/"))
+    apps = root / "usr/share/applications"
+    if not apps.is_dir():
+        return
+    subprocess.run([tool, str(apps)], check=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/usr/share/lpm/hooks/post_install.d/030-update-icon-cache.py
+++ b/usr/share/lpm/hooks/post_install.d/030-update-icon-cache.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def main():
+    tool = shutil.which("gtk-update-icon-cache")
+    if not tool:
+        return
+    root = Path(os.environ.get("LPM_ROOT", "/"))
+    icons_root = root / "usr/share/icons"
+    if not icons_root.is_dir():
+        return
+    for d in icons_root.iterdir():
+        if not d.is_dir():
+            continue
+        if not (d / "index.theme").exists():
+            continue
+        subprocess.run([tool, str(d)], check=False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- run ldconfig, desktop database and icon cache updates through new post-install hooks
- document default hooks and add tests covering hook execution

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5b6622cd88327ad5f6ebb1d1b8fe1