### PR TITLE
Use ok() for buildpkg logging

### DIFF
--- a/lpm.py
+++ b/lpm.py
@@ -1879,9 +1879,7 @@ def cmd_build(a):
 def cmd_buildpkg(a):
     out = run_lpmbuild(a.script, a.outdir, build_deps=not a.no_deps)
     if out and out.exists():
-        # Bold purple output
-        print(f"{PURPLE}[OK] Built {out}{RESET}", file=sys.stderr)
-        print(f"{PURPLE}{out}{RESET}")
+        ok(f"Built {out}")
     else:
         die(f"Build failed for {a.script}")
 


### PR DESCRIPTION
## Summary
- replace direct prints in `cmd_buildpkg` with `ok()` to emit a single green [OK] message including the built file path

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5babe380c8327b02480006e96be4c