### PR TITLE
Handle symlinks in manifest collection

### DIFF
--- a/lpm.py
+++ b/lpm.py
@@ -876,11 +876,17 @@ def collect_manifest(stagedir: Path) -> List[Dict[str,object]]:
                 continue
             f=Path(root)/fn
             rel=f.relative_to(stagedir).as_posix()
-            entry={
-                "path":"/"+rel,
-                "sha256":sha256sum(f),
-                "size":f.stat().st_size
-            }
+            entry={"path":"/"+rel}
+            if f.is_symlink():
+                target=os.readlink(f)
+                st=os.lstat(f)
+                entry["link"]=target
+                entry["sha256"]=hashlib.sha256(target.encode()).hexdigest()
+                entry["size"]=st.st_size
+                mani.append(entry)
+                continue
+            entry["sha256"]=sha256sum(f)
+            entry["size"]=f.stat().st_size
             syms=_extract_symbols(f)
             if syms:
                 entry["symbols"]=syms

--- a/tests/test_collect_manifest_symlink.py
+++ b/tests/test_collect_manifest_symlink.py
@@ -1,0 +1,18 @@
+import os
+import sys
+import hashlib
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from lpm import collect_manifest
+
+
+def test_collect_manifest_handles_broken_symlink(tmp_path):
+    link = tmp_path / "broken"
+    link.symlink_to("missing")
+    mani = collect_manifest(tmp_path)
+    entry = next(e for e in mani if e["path"] == "/broken")
+    assert entry["link"] == "missing"
+    assert entry["sha256"] == hashlib.sha256(b"missing").hexdigest()
+    assert entry["size"] == os.lstat(link).st_size
+    assert "symbols" not in entry
+


### PR DESCRIPTION
## Summary
- handle symlink files in collect_manifest by hashing link target and storing link metadata
- add regression test for broken symlink manifest entries

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5e00c9d608327b7c9078bc905a353