### PR TITLE
Add install script generator

### DIFF
--- a/src/installgen.py
+++ b/src/installgen.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def generate_install_script(stagedir: Path) -> str:
+    cmds: list[str] = []
+
+    apps_dir = stagedir / "usr/share/applications"
+    if apps_dir.is_dir() and any(apps_dir.rglob("*.desktop")):
+        rel = apps_dir.relative_to(stagedir).as_posix()
+        cmds.append(f"update-desktop-database \"${{LPM_ROOT:-/}}/{rel}\"")
+
+    icons_root = stagedir / "usr/share/icons"
+    if icons_root.is_dir():
+        for index in icons_root.glob("*/index.theme"):
+            theme_dir = index.parent.relative_to(stagedir).as_posix()
+            cmds.append(f"gtk-update-icon-cache \"${{LPM_ROOT:-/}}/{theme_dir}\"")
+
+    lib_dir = stagedir / "usr/lib"
+    if lib_dir.is_dir() and any(p.is_file() for p in lib_dir.rglob("*.so*")):
+        cmds.append("if [ \"${LPM_ROOT:-/}\" = \"/\" ]; then ldconfig; fi")
+
+    return "\n".join(cmds)
+
+
+__all__ = ["generate_install_script"]

--- a/tests/test_installgen.py
+++ b/tests/test_installgen.py
@@ -1,0 +1,59 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.installgen import generate_install_script
+
+
+def _setup_tools(tmp_path, names):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "log"
+    for name in names:
+        p = bin_dir / name
+        p.write_text(f"#!/bin/sh\necho {name} >> {log}\n")
+        p.chmod(0o755)
+    return bin_dir, log
+
+
+def test_generate_install_script_runs_required_commands(tmp_path, monkeypatch):
+    stage = tmp_path / "stage"
+    (stage / "usr/share/applications").mkdir(parents=True)
+    (stage / "usr/share/applications/foo.desktop").write_text("[Desktop Entry]")
+    (stage / "usr/share/icons/hicolor").mkdir(parents=True)
+    (stage / "usr/share/icons/hicolor/index.theme").write_text("[Icon Theme]")
+    (stage / "usr/lib").mkdir(parents=True)
+    (stage / "usr/lib/libfoo.so").write_text("")
+
+    script = generate_install_script(stage)
+
+    bin_dir, log = _setup_tools(tmp_path, ["update-desktop-database", "gtk-update-icon-cache", "ldconfig"])
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+
+    subprocess.run(["sh", "-c", script], env={**os.environ, "LPM_ROOT": str(stage)}, check=True)
+
+    calls = log.read_text().splitlines()
+    assert "update-desktop-database" in calls
+    assert "gtk-update-icon-cache" in calls
+    assert "ldconfig" not in calls
+
+
+def test_generate_install_script_ldconfig_only_for_real_root(tmp_path, monkeypatch):
+    stage = tmp_path / "stage"
+    (stage / "usr/lib").mkdir(parents=True)
+    (stage / "usr/lib/libfoo.so.1").write_text("")
+
+    script = generate_install_script(stage)
+
+    bin_dir, log = _setup_tools(tmp_path, ["ldconfig"])
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+
+    subprocess.run(["sh", "-c", script], env={**os.environ, "LPM_ROOT": "/"}, check=True)
+    assert "ldconfig" in log.read_text().splitlines()
+
+    log.write_text("")
+    subprocess.run(["sh", "-c", script], env={**os.environ, "LPM_ROOT": str(stage)}, check=True)
+    assert "ldconfig" not in log.read_text().splitlines()


### PR DESCRIPTION
## Summary
- add `generate_install_script` to craft post-install scripts based on staged files
- test generator for desktop files, icon themes, and conditional `ldconfig`

## Testing
- `pytest tests/test_installgen.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5e32365fc8327baddc228f276b764