### PR TITLE
Generate install scripts during build

### DIFF
--- a/lpm.py
+++ b/lpm.py
@@ -49,6 +49,7 @@ from src.config import (
 )
 initialize_state()
 from src.fs import read_json, write_json, urlread
+from src.installgen import generate_install_script
 from src.solver import CNF, CDCLSolver
 
 # =========================== Protected packages ===============================
@@ -1633,17 +1634,14 @@ def run_lpmbuild(script: Path, outdir: Optional[Path]=None, *, prompt_install: b
                 f.write("\ninstall_script \"$@\"\n")
             install_sh.chmod(0o755)
         else:
+            script = generate_install_script(stagedir)
             with install_sh.open("w", encoding="utf-8") as f:
-                f.write(f"""#!/bin/sh
-set -e
-echo "[lpm] Running default install script for {name}-{version}"
-if command -v ldconfig >/dev/null 2>&1; then
-    echo "[lpm] Running ldconfig"
-    ldconfig || true
-fi
-exit 0
-""")
+                f.write("#!/bin/sh\nset -e\n")
+                f.write(script)
+                if not script.endswith("\n"):
+                    f.write("\n")
             install_sh.chmod(0o755)
+
 
     except Exception as e:
         warn(f"Could not embed install script for {name}: {e}")

--- a/tests/test_run_lpmbuild_install_script.py
+++ b/tests/test_run_lpmbuild_install_script.py
@@ -1,0 +1,35 @@
+import os
+import shutil
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import lpm
+
+def test_run_lpmbuild_generates_install_script(tmp_path, monkeypatch):
+    script = tmp_path / "foo.lpmbuild"
+    script.write_text(
+        "NAME=foo\nVERSION=1\n\nprepare(){ :; }\nbuild(){ :; }\ninstall(){ :; }\n"
+    )
+
+    called = {}
+
+    def fake_generate_install_script(stagedir):
+        called['stagedir'] = stagedir
+        return "echo generated"
+
+    monkeypatch.setattr(lpm, "generate_install_script", fake_generate_install_script)
+    monkeypatch.setattr(lpm, "sandboxed_run", lambda *args, **kwargs: None)
+
+    def fake_build_package(stagedir, meta, out, sign=True):
+        out.write_text("pkg")
+
+    monkeypatch.setattr(lpm, "build_package", fake_build_package)
+
+    lpm.run_lpmbuild(script, outdir=tmp_path, prompt_install=False, build_deps=False)
+
+    install_sh = called['stagedir'] / ".lpm-install.sh"
+    assert install_sh.read_text() == "#!/bin/sh\nset -e\necho generated\n"
+    assert os.access(install_sh, os.X_OK)
+    shutil.rmtree(called['stagedir'])


### PR DESCRIPTION
## Summary
- Generate default install script with `generate_install_script()` when a lpmbuild lacks a custom `install_script`
- Write generated script to staging area and ensure executable
- Test that `run_lpmbuild` embeds the generated install script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5e63645e08327974bbb770871fbbe