### PR TITLE
docs: document automatic install script generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,26 @@ arguments and optional flags.
 - `lpm list` – list installed packages.
 - `lpm verify [--root PATH]` – verify that installed files exist.
 
+When building a package, LPM automatically generates a post-install script if
+the `.lpmbuild` script does not provide one. The script inspects the package
+contents and runs common maintenance commands based on what it finds:
+
+- A desktop entry such as
+  ```
+  usr/share/applications/foo.desktop
+  ```
+  triggers `update-desktop-database "$LPM_ROOT/usr/share/applications"`.
+- An icon theme containing
+  ```
+  usr/share/icons/hicolor/index.theme
+  ```
+  triggers `gtk-update-icon-cache "$LPM_ROOT/usr/share/icons/hicolor"`.
+- Shared libraries like
+  ```
+  usr/lib/libfoo.so
+  ```
+  trigger `ldconfig` when installing into the real root (`/`).
+
 ### Snapshot management
 
 - `lpm snapshots [--delete ID ...] [--prune]` – list or manage filesystem


### PR DESCRIPTION
## Summary
- explain automatic generation of post-install scripts
- show examples mapping package content to maintenance commands

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5e96575c88327a239e26444638379