### PR TITLE
Add CPU detection for ARM and RISC-V architectures

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -78,9 +78,18 @@ def _detect_cpu() -> Tuple[str, str, str, str]:
     try:
         with open("/proc/cpuinfo", "r", encoding="utf-8") as f:
             for line in f:
-                if not vendor and line.startswith("vendor_id"):
+                if not vendor and (
+                    line.startswith("vendor_id")
+                    or line.startswith("CPU implementer")
+                    or line.startswith("uarch")
+                    or line.lower().startswith("vendor")
+                ):
                     vendor = line.split(":", 1)[1].strip()
-                elif not family and line.startswith("cpu family"):
+                elif not family and (
+                    line.startswith("cpu family")
+                    or line.startswith("CPU architecture")
+                    or line.startswith("isa")
+                ):
                     family = line.split(":", 1)[1].strip()
                 if vendor and family:
                     break
@@ -103,6 +112,17 @@ def _detect_cpu() -> Tuple[str, str, str, str]:
     elif vendor == "GenuineIntel":
         if fam and fam >= 6:
             march = mtune = "x86-64-v3"
+    elif vendor in ("0x41", "ARM"):
+        if fam and fam >= 9:
+            march = mtune = "armv9-a"
+        elif fam and fam >= 8:
+            march = mtune = "armv8-a"
+        elif fam and fam >= 7:
+            march = mtune = "armv7-a"
+    elif family.startswith("rv64"):
+        march = mtune = "rv64gc"
+    elif family.startswith("rv32"):
+        march = mtune = "rv32gc"
 
     return march, mtune, vendor, family
 

--- a/tests/test_cpu_detect.py
+++ b/tests/test_cpu_detect.py
@@ -1,0 +1,39 @@
+import builtins
+import io
+
+import src.config as config
+
+
+def _mock_cpuinfo(monkeypatch, text):
+    original_open = builtins.open
+
+    def mock_open(path, *args, **kwargs):
+        if path == "/proc/cpuinfo":
+            return io.StringIO(text)
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", mock_open)
+
+
+def test_detect_arm(monkeypatch):
+    _mock_cpuinfo(
+        monkeypatch,
+        "CPU implementer\t: 0x41\nCPU architecture\t: 8\n",
+    )
+    march, mtune, vendor, family = config._detect_cpu()
+    assert march == "armv8-a"
+    assert mtune == "armv8-a"
+    assert vendor == "0x41"
+    assert family == "8"
+
+
+def test_detect_riscv(monkeypatch):
+    _mock_cpuinfo(
+        monkeypatch,
+        "uarch\t: sifive,u74-mc\nisa\t: rv64imafdc\n",
+    )
+    march, mtune, vendor, family = config._detect_cpu()
+    assert march == "rv64gc"
+    assert mtune == "rv64gc"
+    assert vendor == "sifive,u74-mc"
+    assert family == "rv64imafdc"


### PR DESCRIPTION
## Summary
- extend `_detect_cpu` to parse additional cpuinfo fields and tune for ARM and RISC-V
- add unit tests for ARM and RISC-V cpuinfo detection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6d605b6188327b82f3041a7b002f6