### PR TITLE
Improve Intel CPU detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ configured optimisation level for `CFLAGS` and `CXXFLAGS` while `LDFLAGS` uses
 only the optimisation level. Any `CFLAGS` defined in a `.lpmbuild` script are
 appended to the defaults.
 
+For Intel processors the detection now inspects the `model` and `flags` fields
+from `/proc/cpuinfo`, mapping common family 6 CPUs to GCC's
+`x86-64` micro-architecture levels such as `x86-64-v2`, `x86-64-v3` and
+`x86-64-v4`.  If a CPU cannot be matched to a known level the generic target is
+used.
+
 ## Snapshots
 
 LPM stores filesystem snapshots in `/var/lib/lpm/snapshots`. Configure

--- a/tests/test_config_cpu.py
+++ b/tests/test_config_cpu.py
@@ -1,0 +1,69 @@
+import builtins
+import io
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import src.config as config
+
+
+def mock_cpuinfo(monkeypatch, data: str) -> None:
+    original_open = builtins.open
+
+    def fake_open(path, *args, **kwargs):
+        if path == "/proc/cpuinfo":
+            return io.StringIO(data)
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+
+
+CPUINFO_SNB = """vendor_id\t: GenuineIntel
+cpu family\t: 6
+model\t\t: 42
+flags\t\t: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm ida arat xsaveopt pln pts dtherm
+"""
+
+CPUINFO_HASWELL = """vendor_id\t: GenuineIntel
+cpu family\t: 6
+model\t\t: 60
+flags\t\t: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm ida arat xsaveopt pln pts dtherm avx2 bmi1 bmi2 fma
+"""
+
+CPUINFO_SKX = """vendor_id\t: GenuineIntel
+cpu family\t: 6
+model\t\t: 85
+flags\t\t: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm ida arat xsaveopt pln pts dtherm avx2 bmi1 bmi2 fma avx512f avx512cd avx512dq avx512bw avx512vl
+"""
+
+CPUINFO_GENERIC = """vendor_id\t: GenuineIntel
+cpu family\t: 6
+model\t\t: 1
+flags\t\t: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2
+"""
+
+
+def test_detect_intel_v2(monkeypatch):
+    mock_cpuinfo(monkeypatch, CPUINFO_SNB)
+    march, mtune, vendor, family = config._detect_cpu()
+    assert march == mtune == "x86-64-v2"
+    assert vendor == "GenuineIntel"
+    assert family == "6"
+
+
+def test_detect_intel_v3(monkeypatch):
+    mock_cpuinfo(monkeypatch, CPUINFO_HASWELL)
+    march, mtune, vendor, family = config._detect_cpu()
+    assert march == mtune == "x86-64-v3"
+
+
+def test_detect_intel_v4(monkeypatch):
+    mock_cpuinfo(monkeypatch, CPUINFO_SKX)
+    march, mtune, vendor, family = config._detect_cpu()
+    assert march == mtune == "x86-64-v4"
+
+
+def test_detect_intel_generic(monkeypatch):
+    mock_cpuinfo(monkeypatch, CPUINFO_GENERIC)
+    march, mtune, vendor, family = config._detect_cpu()
+    assert march == mtune == "generic"


### PR DESCRIPTION
## Summary
- Parse Intel CPU model and flags from `/proc/cpuinfo`
- Map Intel family 6 CPUs to GCC targets (x86-64-v2/v3/v4) with generic fallback
- Add unit tests covering Intel CPU detection
- Document expanded detection in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6d75be8d08327bfd85109f636f663