### PR TITLE
Guard install script commands

### DIFF
--- a/src/installgen.py
+++ b/src/installgen.py
@@ -9,17 +9,26 @@ def generate_install_script(stagedir: Path) -> str:
     apps_dir = stagedir / "usr/share/applications"
     if apps_dir.is_dir() and any(apps_dir.rglob("*.desktop")):
         rel = apps_dir.relative_to(stagedir).as_posix()
-        cmds.append(f"update-desktop-database \"${{LPM_ROOT:-/}}/{rel}\"")
+        cmds.append(
+            "command -v update-desktop-database >/dev/null 2>&1 "
+            f"&& update-desktop-database \"${{LPM_ROOT:-/}}/{rel}\" || true"
+        )
 
     icons_root = stagedir / "usr/share/icons"
     if icons_root.is_dir():
         for index in icons_root.glob("*/index.theme"):
             theme_dir = index.parent.relative_to(stagedir).as_posix()
-            cmds.append(f"gtk-update-icon-cache \"${{LPM_ROOT:-/}}/{theme_dir}\"")
+            cmds.append(
+                "command -v gtk-update-icon-cache >/dev/null 2>&1 "
+                f"&& gtk-update-icon-cache \"${{LPM_ROOT:-/}}/{theme_dir}\" || true"
+            )
 
     lib_dir = stagedir / "usr/lib"
     if lib_dir.is_dir() and any(p.is_file() for p in lib_dir.rglob("*.so*")):
-        cmds.append("if [ \"${LPM_ROOT:-/}\" = \"/\" ]; then ldconfig; fi")
+        cmds.append(
+            "[ \"${LPM_ROOT:-/}\" = \"/\" ] && command -v ldconfig >/dev/null 2>&1 "
+            "&& ldconfig || true"
+        )
 
     return "\n".join(cmds)
 

--- a/tests/test_installgen.py
+++ b/tests/test_installgen.py
@@ -41,6 +41,25 @@ def test_generate_install_script_runs_required_commands(tmp_path, monkeypatch):
     assert "ldconfig" not in calls
 
 
+def test_generate_install_script_skips_missing_commands(tmp_path, monkeypatch):
+    stage = tmp_path / "stage"
+    (stage / "usr/share/applications").mkdir(parents=True)
+    (stage / "usr/share/applications/foo.desktop").write_text("[Desktop Entry]")
+    (stage / "usr/share/icons/hicolor").mkdir(parents=True)
+    (stage / "usr/share/icons/hicolor/index.theme").write_text("[Icon Theme]")
+
+    script = generate_install_script(stage)
+
+    bin_dir, log = _setup_tools(tmp_path, ["gtk-update-icon-cache"])
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+
+    subprocess.run(["sh", "-c", script], env={**os.environ, "LPM_ROOT": str(stage)}, check=True)
+
+    calls = log.read_text().splitlines()
+    assert "gtk-update-icon-cache" in calls
+    assert "update-desktop-database" not in calls
+
+
 def test_generate_install_script_ldconfig_only_for_real_root(tmp_path, monkeypatch):
     stage = tmp_path / "stage"
     (stage / "usr/lib").mkdir(parents=True)


### PR DESCRIPTION
## Summary
- Wrap generated install commands with `command -v` checks so they only run when available
- Ensure missing tools do not cause install script to fail
- Test skipping of unavailable commands and ldconfig-only-for-root behavior

## Testing
- `pytest tests/test_installgen.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6d998e1048327a3a526036bbc52ac