### PR TITLE
Track package dependencies and add autoremove

### DIFF
--- a/tests/test_autoremove.py
+++ b/tests/test_autoremove.py
@@ -1,0 +1,65 @@
+import os, sys, json, shutil, importlib, dataclasses, tarfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+def _import_lpm(tmp_path, monkeypatch):
+    monkeypatch.setenv("LPM_STATE_DIR", str(tmp_path/"state"))
+    for mod in ["lpm", "src.config"]:
+        if mod in sys.modules:
+            del sys.modules[mod]
+    return importlib.import_module("lpm")
+
+
+def _make_pkg(lpm, tmp_path, name, requires=None):
+    staged = tmp_path / f"stage-{name}"
+    staged.mkdir()
+    data_file = staged / "file"
+    data_file.write_text("content")
+    meta = lpm.PkgMeta(name=name, version="1", release="1", arch="noarch", requires=requires or [])
+    manifest = [{
+        "path": "/file",
+        "size": len("content"),
+        "sha256": lpm.sha256sum(data_file),
+    }]
+    (staged/".lpm-meta.json").write_text(json.dumps(dataclasses.asdict(meta)))
+    (staged/".lpm-manifest.json").write_text(json.dumps(manifest))
+    out = tmp_path / f"{name}.zst"
+    with out.open("wb") as f:
+        cctx = lpm.zstd.ZstdCompressor()
+        with cctx.stream_writer(f) as compressor:
+            with tarfile.open(fileobj=compressor, mode="w|") as tf:
+                for p in staged.iterdir():
+                    tf.add(p, arcname=p.name)
+    shutil.rmtree(staged)
+    return out
+
+
+def test_autoremove_removes_unused_dependency(tmp_path, monkeypatch):
+    lpm = _import_lpm(tmp_path, monkeypatch)
+    monkeypatch.setattr(lpm.shutil, "which", lambda cmd: "/usr/bin/true")
+    root = tmp_path / "root"
+    root.mkdir()
+
+    dep_pkg = _make_pkg(lpm, tmp_path, "dep")
+    pkg_pkg = _make_pkg(lpm, tmp_path, "pkg", ["dep"])
+
+    lpm.installpkg(dep_pkg, root=root, dry_run=False, verify=False, force=False, explicit=False)
+    lpm.installpkg(pkg_pkg, root=root, dry_run=False, verify=False, force=False, explicit=True)
+
+    conn = lpm.db()
+    row = conn.execute("SELECT requires,explicit FROM installed WHERE name='pkg'").fetchone()
+    assert json.loads(row[0]) == ["dep"]
+    assert row[1] == 1
+    row = conn.execute("SELECT explicit FROM installed WHERE name='dep'").fetchone()
+    assert row[0] == 0
+    conn.close()
+
+    lpm.do_remove(["pkg"], root=root, dry=False)
+    lpm.autoremove(root=root, dry=False)
+
+    conn = lpm.db()
+    remaining = conn.execute("SELECT name FROM installed").fetchall()
+    conn.close()
+    assert remaining == []

--- a/tests/test_install_script_generator.py
+++ b/tests/test_install_script_generator.py
@@ -18,7 +18,7 @@ def test_desktop_file_triggers_update_desktop_database(tmp_path):
 
     assert (
         script
-        == 'update-desktop-database "${LPM_ROOT:-/}/usr/share/applications"'
+        == 'command -v update-desktop-database >/dev/null 2>&1 && update-desktop-database "${LPM_ROOT:-/}/usr/share/applications" || true'
     )
 
 
@@ -32,7 +32,7 @@ def test_icon_theme_triggers_icon_cache_update(tmp_path):
 
     assert (
         script
-        == 'gtk-update-icon-cache "${LPM_ROOT:-/}/usr/share/icons/hicolor"'
+        == 'command -v gtk-update-icon-cache >/dev/null 2>&1 && gtk-update-icon-cache "${LPM_ROOT:-/}/usr/share/icons/hicolor" || true'
     )
 
 
@@ -44,5 +44,5 @@ def test_shared_library_triggers_ldconfig(tmp_path):
 
     script = generate_install_script(stage)
 
-    assert script == 'if [ "${LPM_ROOT:-/}" = "/" ]; then ldconfig; fi'
+    assert script == '[ "${LPM_ROOT:-/}" = "/" ] && command -v ldconfig >/dev/null 2>&1 && ldconfig || true'
 


### PR DESCRIPTION
## Summary
- record dependency and explicit flags in installed package database
- persist dependency info during installs/upgrades and add `autoremove` command to prune unused packages
- update install script generator tests and add coverage for autoremove

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6ddb826cc8327a78c90b80c15722f