### PR TITLE
Add cache clean command

### DIFF
--- a/lpm.py
+++ b/lpm.py
@@ -2109,6 +2109,17 @@ def cmd_genindex(a):
     repo_dir = Path(a.repo_dir)
     gen_index(repo_dir, a.base_url, arch_filter=a.arch)
 
+def cmd_clean_cache(_):
+    if CACHE_DIR.exists():
+        for p in CACHE_DIR.iterdir():
+            if p.is_dir():
+                shutil.rmtree(p)
+            else:
+                p.unlink()
+        ok("Removed cached blobs")
+    else:
+        log("No cache directory")
+
 def cmd_fileremove(a):
     root = Path(a.root or DEFAULT_ROOT)
 
@@ -2374,6 +2385,8 @@ def build_parser()->argparse.ArgumentParser:
     sp=sub.add_parser("repolist", help="Show configured repositories"); sp.set_defaults(func=cmd_repolist)
     sp=sub.add_parser("repoadd", help="Add a repository"); sp.add_argument("name"); sp.add_argument("url");                   sp.add_argument("--priority",type=int,default=10); sp.set_defaults(func=cmd_repoadd)
     sp=sub.add_parser("repodel", help="Remove a repository"); sp.add_argument("name"); sp.set_defaults(func=cmd_repodel)
+
+    sp=sub.add_parser("clean", help="Remove cached blobs"); sp.set_defaults(func=cmd_clean_cache)
 
     sp=sub.add_parser("search", help="Search packages"); sp.add_argument("patterns", nargs="*"); sp.set_defaults(func=cmd_search)
     sp=sub.add_parser("info", help="Show package info"); sp.add_argument("names", nargs="+"); sp.set_defaults(func=cmd_info)

--- a/tests/test_clean_cache.py
+++ b/tests/test_clean_cache.py
@@ -1,0 +1,29 @@
+import sys, importlib
+from types import SimpleNamespace
+
+
+def _import_lpm(tmp_path, monkeypatch):
+    monkeypatch.setenv("LPM_STATE_DIR", str(tmp_path/"state"))
+    for mod in ["lpm", "src.config"]:
+        if mod in sys.modules:
+            del sys.modules[mod]
+    return importlib.import_module("lpm")
+
+
+def test_clean_cache_removes_only_cached_files(tmp_path, monkeypatch):
+    lpm = _import_lpm(tmp_path, monkeypatch)
+    cache = lpm.CACHE_DIR
+    (cache / "blob1").write_text("data1")
+    subdir = cache / "sub"
+    subdir.mkdir()
+    (subdir / "blob2").write_text("data2")
+
+    other_file = cache.parent / "other.txt"
+    other_file.write_text("keep")
+
+    lpm.cmd_clean_cache(SimpleNamespace())
+
+    assert not (cache / "blob1").exists()
+    assert not subdir.exists()
+    assert other_file.exists()
+    assert list(cache.iterdir()) == []


### PR DESCRIPTION
## Summary
- add cmd_clean_cache to purge cached blobs
- expose new `clean` subcommand in CLI parser
- test cache cleaning behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6e1f114d483278e6cdc0c27fbb94f