### PR TITLE
Add files subcommand to list installed package files

### DIFF
--- a/lpm.py
+++ b/lpm.py
@@ -1951,6 +1951,18 @@ def cmd_upgrade(a):
             warn(f"Snapshot {snapshot_id} created at {snapshot_archive} for rollback.")
         raise
 
+def cmd_files(a):
+    conn = db()
+    row = conn.execute("SELECT manifest FROM installed WHERE name=?", (a.name,)).fetchone()
+    conn.close()
+    if not row:
+        warn(f"{a.name} not installed")
+        return
+    mani = json.loads(row[0]) if row[0] else []
+    for e in mani:
+        path = e["path"] if isinstance(e, dict) else e
+        print(path)
+
 def cmd_list_installed(_):
     conn=db()
     for n,v,r,a in conn.execute("SELECT name,version,release,arch FROM installed ORDER BY name"):
@@ -2419,6 +2431,7 @@ def build_parser()->argparse.ArgumentParser:
     sp.set_defaults(func=cmd_upgrade)
 
     sp=sub.add_parser("list", help="List installed packages"); sp.set_defaults(func=cmd_list_installed)
+    sp=sub.add_parser("files", help="List files installed by package"); sp.add_argument("name"); sp.set_defaults(func=cmd_files)
     sp=sub.add_parser("snapshots", help="List snapshots"); sp.add_argument("--delete", type=int, nargs="*", help="snapshot IDs to delete"); sp.add_argument("--prune", action="store_true", help="prune old snapshots"); sp.set_defaults(func=cmd_snapshots)
     sp=sub.add_parser("rollback", help="Restore from snapshot"); sp.add_argument("snapshot_id", nargs="?", type=int, help="snapshot ID (default latest)"); sp.set_defaults(func=cmd_rollback)
     sp=sub.add_parser("history", help="Show last transactions"); sp.set_defaults(func=cmd_history)

--- a/tests/test_cmd_files.py
+++ b/tests/test_cmd_files.py
@@ -1,0 +1,27 @@
+import sys, importlib, json
+from types import SimpleNamespace
+
+
+def _import_lpm(tmp_path, monkeypatch):
+    monkeypatch.setenv("LPM_STATE_DIR", str(tmp_path / "state"))
+    for mod in ["lpm", "src.config"]:
+        if mod in sys.modules:
+            del sys.modules[mod]
+    return importlib.import_module("lpm")
+
+
+def test_cmd_files_lists_manifest(tmp_path, monkeypatch, capsys):
+    lpm = _import_lpm(tmp_path, monkeypatch)
+    conn = lpm.db()
+    manifest = ["/a", {"path": "/b"}, "/c"]
+    conn.execute(
+        "INSERT INTO installed (name,version,release,arch,provides,symbols,requires,manifest,explicit,install_time)"
+        " VALUES (?,?,?,?,?,?,?,?,?,?)",
+        ("pkg", "1", "1", "noarch", "[]", "[]", "[]", json.dumps(manifest), 1, 0),
+    )
+    conn.commit()
+    conn.close()
+
+    lpm.cmd_files(SimpleNamespace(name="pkg"))
+    captured = capsys.readouterr()
+    assert captured.out.splitlines() == ["/a", "/b", "/c"]


### PR DESCRIPTION
## Summary
- add `cmd_files` to print file manifest from installed database
- wire up new `files` subcommand in CLI parser
- test command to ensure file paths are listed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6e74e8d208327bccaf7b45ef52dcc