### PR TITLE
Validate CPU_TYPE configuration and add negative tests

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import logging
 from pathlib import Path
 from typing import Dict, Tuple
 
@@ -149,6 +150,7 @@ def _init_cpu_settings() -> Tuple[str, str, str, str]:
         norm = _normalize_cpu_type(cpu_type)
         if norm:
             return norm, norm, "", ""
+        logging.warning("Unrecognized CPU_TYPE %r; falling back to auto-detected CPU settings", cpu_type)
     return _detect_cpu()
 
 


### PR DESCRIPTION
## Summary
- validate `CPU_TYPE` values and warn while falling back to auto-detection
- test that invalid `CPU_TYPE` settings do not crash and use auto-detected values

## Testing
- `pytest tests/test_config_cpu.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6ef267d5c8327a69562357a55a886