### PR TITLE
Add switchable lpmbuild fallback control

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ arguments and optional flags.
 
 ### Package installation and removal
 
-- `lpm install NAME... [--root PATH] [--dry-run] [--no-verify]`
+- `lpm install NAME... [--root PATH] [--dry-run] [--no-verify] [--allow-fallback|--no-fallback]`
 - `lpm remove NAME... [--root PATH] [--dry-run] [--force]`
-- `lpm upgrade [NAME ...] [--root PATH] [--dry-run] [--no-verify] [--force]`
+- `lpm upgrade [NAME ...] [--root PATH] [--dry-run] [--no-verify] [--allow-fallback|--no-fallback] [--force]`
 - `lpm list` – list installed packages.
 - `lpm verify [--root PATH]` – verify that installed files exist.
 
@@ -133,6 +133,13 @@ LPM stores filesystem snapshots in `/var/lib/lpm/snapshots`. Configure
 (default `10`). Older entries beyond the limit are automatically pruned after
 creating a new snapshot. You can trigger cleanup manually with
 `lpm snapshots --prune`.
+
+By default hardened installations disable the GitLab fallback that fetches
+`.lpmbuild` scripts when a repository download fails. Set
+`ALLOW_LPMBUILD_FALLBACK=true` in `/etc/lpm/lpm.conf` to re-enable this
+behaviour globally. You can override the setting per invocation using
+`lpm install ... --allow-fallback` or `--no-fallback`, and the same switches on
+`lpm upgrade`.
 
 ## Bootstrap
 

--- a/src/config.py
+++ b/src/config.py
@@ -50,6 +50,13 @@ def load_conf(path: Path) -> Dict[str, str]:
 CONF = load_conf(CONF_FILE)
 ARCH = CONF.get("ARCH", os.uname().machine if hasattr(os, "uname") else "x86_64")
 
+
+def _get_bool(key: str, default: bool) -> bool:
+    val = CONF.get(key)
+    if val is None:
+        return default
+    return val.strip().lower() in {"1", "true", "yes", "on"}
+
 # --- Optimization level (-O2 etc.) ---
 OPT_LEVEL = CONF.get("OPT_LEVEL", "-O2")
 if OPT_LEVEL not in ("-Os", "-O2", "-O3", "-Ofast"):
@@ -71,6 +78,9 @@ except ValueError:
 INSTALL_PROMPT_DEFAULT = CONF.get("INSTALL_PROMPT_DEFAULT", "n").lower()
 if INSTALL_PROMPT_DEFAULT not in ("y", "n"):
     INSTALL_PROMPT_DEFAULT = "n"
+
+# --- Hardened install behaviour ---
+ALLOW_LPMBUILD_FALLBACK = _get_bool("ALLOW_LPMBUILD_FALLBACK", False)
 
 
 def _detect_cpu() -> Tuple[str, str, str, str]:
@@ -192,6 +202,7 @@ __all__ = [
     "MAX_SNAPSHOTS",
     "MAX_LEARNT_CLAUSES",
     "INSTALL_PROMPT_DEFAULT",
+    "ALLOW_LPMBUILD_FALLBACK",
     "MARCH",
     "MTUNE",
     "CPU_VENDOR",


### PR DESCRIPTION
## Summary
- add an `ALLOW_LPMBUILD_FALLBACK` configuration knob that defaults to hardened installs
- gate the GitLab `.lpmbuild` fallback behind the configuration value with `--allow-fallback` / `--no-fallback` overrides
- document the new command line switches and configuration option in the README

## Testing
- pytest *(fails: missing zstandard and hypothesis test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cb450be1748327a8b69232ec31afb4