### PR TITLE
Add default config packaging and staging updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,25 +5,7 @@ ENTRY = $(PWD)/lpm.py
 BUILD_DIR = build/nuitka
 DIST_DIR = dist
 SRC_FILES := $(shell find src -type f -name '*.py')
-VERSION ?= $(shell $(PYTHON) - <<'PY'
-import pathlib
-import re
-import subprocess
-root = pathlib.Path(__file__).resolve().parent
-version = None
-lpm_path = root / "lpm.py"
-if lpm_path.exists():
-    match = re.search(r"__version__\s*=\s*['\"]([^'\"]+)['\"]", lpm_path.read_text(encoding="utf-8"))
-    if match:
-        version = match.group(1)
-if version is None:
-    try:
-        version = subprocess.check_output(["git", "describe", "--tags", "--always"], cwd=root).decode().strip()
-    except Exception:
-        version = "0.0.0"
-print(version)
-PY
-)
+VERSION ?= $(shell $(PYTHON) tools/get_version.py)
 
 export PYTHONPATH := $(PWD)$(if $(PYTHONPATH),:$(PYTHONPATH),)
 
@@ -33,6 +15,7 @@ TARBALL = $(DIST_DIR)/$(APP)-$(VERSION).tar.gz
 HOOK_SRC = usr/share/lpm/hooks
 
 .PHONY: all stage tarball clean distclean
+.ONESHELL:
 
 all: $(BIN_TARGET)
 
@@ -40,53 +23,55 @@ $(BIN_TARGET): lpm.py $(SRC_FILES)
 	@mkdir -p $(BUILD_DIR)
 	$(NUITKA) --onefile --include-package=src --follow-imports --output-dir=$(BUILD_DIR) --output-filename=$(APP).bin $(ENTRY)
 
-$(STAGING_DIR): $(BIN_TARGET) README.md LICENSE
+$(STAGING_DIR): $(BIN_TARGET) README.md LICENSE etc/lpm/lpm.conf
 	@mkdir -p $(DIST_DIR)
 	@rm -rf $@
 	mkdir -p $@/bin
 	cp $(BIN_TARGET) $@/bin/$(APP)
 	mkdir -p $@/usr/share/lpm
 	cp -R $(HOOK_SRC) $@/usr/share/lpm/
+	mkdir -p $@/etc/lpm
+	cp etc/lpm/lpm.conf $@/etc/lpm/lpm.conf
 	cp README.md LICENSE $@
-	cat <<'INSTALL_SH' > $@/install.sh
-#!/bin/sh
-set -eu
-PREFIX="${PREFIX:-/usr/local}"
-DESTDIR="${DESTDIR:-}"
-ROOT="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
-
-mkdir -p "${DESTDIR}${PREFIX}/bin"
-install -m 0755 "${ROOT}/bin/lpm" "${DESTDIR}${PREFIX}/bin/lpm"
-
-HOOK_DEST="${DESTDIR}/usr/share/lpm"
-rm -rf "${HOOK_DEST}/hooks"
-mkdir -p "${HOOK_DEST}"
-cp -R "${ROOT}/usr/share/lpm/hooks" "${HOOK_DEST}/"
-
-STATE_DIR="${DESTDIR}/var/lib/lpm"
-mkdir -p "${STATE_DIR}/cache" "${STATE_DIR}/snapshots"
-if [ ! -f "${STATE_DIR}/repos.json" ]; then
-    printf '[]\n' > "${STATE_DIR}/repos.json"
-fi
-if [ ! -f "${STATE_DIR}/pins.json" ]; then
-    cat > "${STATE_DIR}/pins.json" <<'JSON'
-{
-  "hold": [],
-  "prefer": {}
-}
-JSON
-fi
-
-CONF_DIR="${DESTDIR}/etc/lpm"
-mkdir -p "${CONF_DIR}"
-if [ ! -f "${CONF_DIR}/lpm.conf" ]; then
-    cat > "${CONF_DIR}/lpm.conf" <<'CONF'
-# LPM configuration
-# ARCH=<architecture>
-# OPT_LEVEL=-O2
-CONF
-fi
-INSTALL_SH
+	cat <<-'INSTALL_SH' > $@/install.sh
+	#!/bin/sh
+	set -eu
+	PREFIX="$${PREFIX:-/usr/local}"
+	DESTDIR="$${DESTDIR:-}"
+	ROOT="$$(CDPATH= cd -- "$$(dirname "$$0")" && pwd)"
+	
+	mkdir -p "$${DESTDIR}$${PREFIX}/bin"
+	install -m 0755 "$${ROOT}/bin/lpm" "$${DESTDIR}$${PREFIX}/bin/lpm"
+	
+	HOOK_DEST="$${DESTDIR}/usr/share/lpm"
+	rm -rf "$${HOOK_DEST}/hooks"
+	mkdir -p "$${HOOK_DEST}"
+	cp -R "$${ROOT}/usr/share/lpm/hooks" "$${HOOK_DEST}/"
+	
+	STATE_DIR="$${DESTDIR}/var/lib/lpm"
+	mkdir -p "$${STATE_DIR}/cache" "$${STATE_DIR}/snapshots"
+	if [ ! -f "$${STATE_DIR}/repos.json" ]; then
+	    printf '[]\n' > "$${STATE_DIR}/repos.json"
+	fi
+	if [ ! -f "$${STATE_DIR}/pins.json" ]; then
+	    cat > "$${STATE_DIR}/pins.json" <<'JSON'
+	{
+	  "hold": [],
+	  "prefer": {}
+	}
+	JSON
+	fi
+	
+	CONF_DIR="$${DESTDIR}/etc/lpm"
+	mkdir -p "$${CONF_DIR}"
+	CONF_SRC="$${ROOT}/etc/lpm/lpm.conf"
+	CONF_DEST="$${CONF_DIR}/lpm.conf"
+	if [ ! -f "$${CONF_DEST}" ]; then
+	    install -m 0644 "$${CONF_SRC}" "$${CONF_DEST}"
+	else
+	    printf 'Keeping existing configuration: %s\n' "$${CONF_DEST}"
+	fi
+	INSTALL_SH
 	chmod +x $@/install.sh
 
 $(TARBALL): $(STAGING_DIR)

--- a/etc/lpm/lpm.conf
+++ b/etc/lpm/lpm.conf
@@ -1,0 +1,29 @@
+# LPM configuration file
+#
+# Lines use KEY=VALUE syntax. Remove the leading '#' to override a setting.
+# Defaults shown here match the built-in behaviour described in the README.
+
+# ARCH overrides the detected architecture reported by `uname -m`.
+# ARCH=$(uname -m)
+
+# OPT_LEVEL controls the default optimisation flags used during builds.
+# Valid values: -Os, -O2, -O3, -Ofast
+# OPT_LEVEL=-O2
+
+# MAX_SNAPSHOTS limits how many filesystem snapshots are retained.
+# MAX_SNAPSHOTS=10
+
+# MAX_LEARNT_CLAUSES bounds the SAT solver's learnt clause count.
+# MAX_LEARNT_CLAUSES=200
+
+# INSTALL_PROMPT_DEFAULT selects the default answer for install prompts.
+# Valid values: y, n
+# INSTALL_PROMPT_DEFAULT=n
+
+# ALLOW_LPMBUILD_FALLBACK restores the network fallback for .lpmbuild scripts.
+# Set to true to re-enable downloads when repository fetches fail.
+# ALLOW_LPMBUILD_FALLBACK=false
+
+# CPU_TYPE forces generic CPU tuning instead of auto-detection.
+# Accepted values: x86_64v1, x86_64v2, x86_64v3, x86_64v4
+# CPU_TYPE=

--- a/tools/get_version.py
+++ b/tools/get_version.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+
+
+def main() -> None:
+    root = pathlib.Path(__file__).resolve().parents[1]
+    version: str | None = None
+    lpm_path = root / "lpm.py"
+    if lpm_path.exists():
+        match = re.search(r"__version__\s*=\s*['\"]([^'\"]+)['\"]", lpm_path.read_text(encoding="utf-8"))
+        if match:
+            version = match.group(1)
+    if version is None:
+        try:
+            version = subprocess.check_output([
+                "git",
+                "describe",
+                "--tags",
+                "--always",
+            ], cwd=root).decode().strip()
+        except Exception:
+            version = "0.0.0"
+    print(version)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a tracked default configuration at etc/lpm/lpm.conf with commented defaults
- update the Makefile staging flow to install the packaged config and preserve user settings
- replace the inline version shell snippet with a helper script and enable .ONESHELL for the recipes

## Testing
- make distclean
- make stage
- make tarball
- tar -tzf dist/lpm-$(python tools/get_version.py).tar.gz | grep lpm.conf

------
https://chatgpt.com/codex/tasks/task_e_68cc34a2f3788327b9b81f4f0ac034fb