### PR TITLE
Add runtime metadata helper and tests

### DIFF
--- a/lpm.py
+++ b/lpm.py
@@ -24,6 +24,36 @@ from typing import Dict, List, Optional, Set, Tuple, Iterable
 from collections import deque
 import zstandard as zstd
 
+# =========================== Runtime metadata =================================
+_ENV_VERSION = "LPM_VERSION"
+_ENV_BUILD = "LPM_BUILD"
+_ENV_BUILD_DATE = "LPM_BUILD_DATE"
+
+_DEFAULT_VERSION = "0.0.0"
+_DEFAULT_BUILD = "development"
+_DEFAULT_BUILD_DATE = ""
+
+__version__ = os.environ.get(_ENV_VERSION, _DEFAULT_VERSION)
+__build__ = os.environ.get(_ENV_BUILD, _DEFAULT_BUILD)
+__build_date__ = os.environ.get(_ENV_BUILD_DATE, _DEFAULT_BUILD_DATE)
+
+
+def get_runtime_metadata() -> Dict[str, str]:
+    """Return runtime metadata describing the current LPM build.
+
+    The module level ``__version__``, ``__build__``, and ``__build_date__``
+    constants default to static fallback values but can be overridden via the
+    ``LPM_VERSION``, ``LPM_BUILD``, and ``LPM_BUILD_DATE`` environment
+    variables. Importing :mod:`lpm` merely exposes these values without
+    triggering the heavier initialization logic below.
+    """
+
+    return {
+        "version": __version__,
+        "build": __build__,
+        "build_date": __build_date__,
+    }
+
 from src.config import (
     ARCH,
     ALLOW_LPMBUILD_FALLBACK,

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,89 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+@pytest.fixture
+def import_lpm():
+    original = sys.modules.get("lpm")
+    stubbed_modules: dict[str, bool] = {}
+
+    for name in ("zstandard", "tqdm"):
+        if name not in sys.modules:
+            module = types.ModuleType(name)
+            if name == "tqdm":
+                class _DummyTqdm:  # pragma: no cover - test helper
+                    def __init__(self, iterable=None, **kwargs):
+                        self.iterable = iterable
+                        self.n = 0
+                        self.total = kwargs.get("total")
+
+                    def __iter__(self):
+                        return iter(self.iterable or [])
+
+                    def __enter__(self):
+                        return self
+
+                    def __exit__(self, exc_type, exc, tb):
+                        return False
+
+                    def update(self, *args, **kwargs):
+                        return None
+
+                module.tqdm = _DummyTqdm  # type: ignore[attr-defined]
+            sys.modules[name] = module
+            stubbed_modules[name] = True
+
+    def _import():
+        sys.modules.pop("lpm", None)
+        return importlib.import_module("lpm")
+
+    try:
+        yield _import
+    finally:
+        if original is not None:
+            sys.modules["lpm"] = original
+        else:
+            sys.modules.pop("lpm", None)
+
+        for name, created in stubbed_modules.items():
+            if created:
+                sys.modules.pop(name, None)
+
+
+def test_get_runtime_metadata_defaults(monkeypatch, import_lpm):
+    monkeypatch.delenv("LPM_VERSION", raising=False)
+    monkeypatch.delenv("LPM_BUILD", raising=False)
+    monkeypatch.delenv("LPM_BUILD_DATE", raising=False)
+
+    mod = import_lpm()
+    metadata = mod.get_runtime_metadata()
+
+    assert set(metadata) == {"version", "build", "build_date"}
+    assert metadata["version"] == mod.__version__
+    assert metadata["build"] == mod.__build__
+    assert metadata["build_date"] == mod.__build_date__
+
+
+def test_get_runtime_metadata_env_override(monkeypatch, import_lpm):
+    monkeypatch.setenv("LPM_VERSION", "1.2.3")
+    monkeypatch.setenv("LPM_BUILD", "abc123")
+    monkeypatch.setenv("LPM_BUILD_DATE", "2024-01-02T03:04:05Z")
+
+    mod = import_lpm()
+    metadata = mod.get_runtime_metadata()
+
+    assert metadata == {
+        "version": "1.2.3",
+        "build": "abc123",
+        "build_date": "2024-01-02T03:04:05Z",
+    }
+    assert mod.__version__ == "1.2.3"
+    assert mod.__build__ == "abc123"
+    assert mod.__build_date__ == "2024-01-02T03:04:05Z"

--- a/tools/get_version.py
+++ b/tools/get_version.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
+"""Utility for retrieving the LPM version string.
+
+The value is sourced from ``lpm.__version__`` which itself honours the
+``LPM_VERSION`` environment variable (falling back to a static default).
+When the constant is unavailable the script falls back to ``git describe`` to
+mirror the previous behaviour.
+"""
+
 import pathlib
 import re
 import subprocess


### PR DESCRIPTION
## Summary
- define module metadata constants in `lpm.py` with a helper returning them and documenting environment overrides
- update `tools/get_version.py` documentation to reflect the metadata source
- add a metadata unit test that stubs optional dependencies and checks defaults plus environment overrides

## Testing
- pytest tests/test_metadata.py

------
https://chatgpt.com/codex/tasks/task_e_68cc3f5ea4c48327aa4e03490d784e7c