### PR TITLE
Ensure lpmbuild uses safe arch default

### DIFF
--- a/lpm.py
+++ b/lpm.py
@@ -1704,7 +1704,9 @@ def run_lpmbuild(script: Path, outdir: Optional[Path]=None, *, prompt_install: b
     name = scal.get("NAME", "")
     version = scal.get("VERSION", "")
     release = scal.get("RELEASE", "1")
-    arch = scal.get("ARCH") or ARCH
+    arch = (scal.get("ARCH") or ARCH or "").strip()
+    if not arch:
+        arch = PkgMeta.__dataclass_fields__["arch"].default
     summary = scal.get("SUMMARY", "")
     url = scal.get("URL", "")
     license_ = scal.get("LICENSE", "")


### PR DESCRIPTION
## Summary
- ensure `run_lpmbuild` normalizes the ARCH value and falls back to the package metadata default when blank
- add a regression test covering packages built without ARCH metadata to ensure the output filename has only a single `.zst`

## Testing
- pytest tests/test_run_lpmbuild_install_script.py

------
https://chatgpt.com/codex/tasks/task_e_68ccc5a6434c8327a7fa8eaaf8789bc1