### PR TITLE
Add Arch PKGBUILD compatibility tooling

### DIFF
--- a/src/arch_compat.py
+++ b/src/arch_compat.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+import logging
+import re
+import shlex
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from .config import ARCH_REPO_ENDPOINTS
+from .fs import urlread
+
+PACMAN_RE = re.compile(r"\b(pacman|libalpm)\b")
+FUNC_RE = re.compile(r"(^|\n)\s*(?:function\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*\(\)\s*\{", re.MULTILINE)
+
+
+@dataclass
+class PKGBuildInfo:
+    name: str
+    version: str
+    release: str
+    summary: str
+    arch: List[str]
+    url: str
+    license: List[str]
+    depends: List[str]
+    makedepends: List[str]
+    optdepends: List[str]
+    provides: List[str]
+    conflicts: List[str]
+    replaces: List[str]
+    source: List[str]
+    epoch: Optional[str] = None
+
+    def dependency_names(self) -> List[str]:
+        seen: Dict[str, None] = {}
+        for raw in self.depends + self.makedepends:
+            name = normalize_dependency_name(raw)
+            if name and name not in seen:
+                seen[name] = None
+        return list(seen.keys())
+
+
+def normalize_dependency_name(dep: str) -> str:
+    text = dep.strip().strip("'\"")
+    if not text:
+        return ""
+    if ":" in text:
+        text = text.split(":", 1)[0]
+    for sep in (">=", "<=", "=", ">", "<"):
+        if sep in text:
+            text = text.split(sep, 1)[0]
+            break
+    match = re.match(r"[A-Za-z0-9@._+-]+", text)
+    return match.group(0) if match else text
+
+
+def _parse_assignments(text: str) -> Dict[str, str]:
+    assignments: Dict[str, str] = {}
+    current_key: Optional[str] = None
+    buffer: List[str] = []
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        if current_key:
+            buffer.append(line)
+            if line.endswith(")"):
+                assignments[current_key] = " ".join(buffer)
+                current_key = None
+                buffer = []
+            continue
+
+        if "=" not in line or line.endswith("()"):
+            continue
+
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if value.startswith("(") and not value.endswith(")"):
+            current_key = key
+            buffer = [value]
+            continue
+        assignments[key] = value
+
+    return assignments
+
+
+def _parse_array(value: Optional[str]) -> List[str]:
+    if not value:
+        return []
+    text = value.strip()
+    if text.startswith("(") and text.endswith(")"):
+        text = text[1:-1]
+    try:
+        return shlex.split(text)
+    except ValueError:
+        return [item for item in text.replace("\n", " ").split(" ") if item]
+
+
+def _parse_scalar(value: Optional[str]) -> str:
+    if not value:
+        return ""
+    value = value.strip()
+    if value.startswith("(") and value.endswith(")"):
+        arr = _parse_array(value)
+        return arr[0] if arr else ""
+    try:
+        parts = shlex.split(value)
+    except ValueError:
+        return value.strip("'\"")
+    return parts[0] if parts else ""
+
+
+def _extract_functions(text: str) -> Dict[str, str]:
+    functions: Dict[str, str] = {}
+    for match in FUNC_RE.finditer(text):
+        name = match.group(2)
+        start = match.end()
+        depth = 1
+        pos = start
+        while pos < len(text) and depth > 0:
+            ch = text[pos]
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+            pos += 1
+        body = text[start:pos - 1].strip()
+        functions[name] = body
+    return functions
+
+
+def _sanitize_body(body: str) -> str:
+    cleaned: List[str] = []
+    for line in body.splitlines():
+        if PACMAN_RE.search(line):
+            continue
+        cleaned.append(line.rstrip())
+    return "\n".join(ln for ln in cleaned if ln.strip())
+
+
+def _format_scalar(name: str, value: str) -> str:
+    if value == "":
+        return f"{name}="
+    if re.match(r"^[A-Za-z0-9@._+-]+$", value):
+        return f"{name}={value}"
+    return f"{name}={shlex.quote(value)}"
+
+
+def _format_array(name: str, values: Sequence[str]) -> str:
+    if not values:
+        return f"{name}=()"
+    quoted = " ".join(shlex.quote(v) for v in values)
+    return f"{name}=({quoted})"
+
+
+def _format_function(name: str, body: str) -> str:
+    lines = [f"{name}() {{"]
+    body = body.strip("\n")
+    if body:
+        for ln in body.splitlines():
+            if ln.strip():
+                lines.append(f"    {ln.rstrip()}")
+            else:
+                lines.append("")
+    else:
+        lines.append("    :")
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def parse_pkgbuild(text: str) -> Tuple[PKGBuildInfo, Dict[str, str]]:
+    assignments = _parse_assignments(text)
+    functions = _extract_functions(text)
+
+    pkgname_values = _parse_array(assignments.get("pkgname"))
+    name = pkgname_values[0] if pkgname_values else _parse_scalar(assignments.get("pkgname"))
+    pkgver = _parse_scalar(assignments.get("pkgver")) or "0"
+    pkgrel = _parse_scalar(assignments.get("pkgrel")) or "1"
+    epoch = _parse_scalar(assignments.get("epoch")) or None
+    summary = _parse_scalar(assignments.get("pkgdesc"))
+    arch = _parse_array(assignments.get("arch"))
+    url = _parse_scalar(assignments.get("url"))
+    license_ = _parse_array(assignments.get("license"))
+    depends = _parse_array(assignments.get("depends"))
+    makedepends = _parse_array(assignments.get("makedepends"))
+    optdepends = _parse_array(assignments.get("optdepends"))
+    provides = _parse_array(assignments.get("provides"))
+    conflicts = _parse_array(assignments.get("conflicts"))
+    replaces = _parse_array(assignments.get("replaces"))
+    source = _parse_array(assignments.get("source"))
+
+    info = PKGBuildInfo(
+        name=name,
+        version=pkgver,
+        release=pkgrel,
+        summary=summary,
+        arch=arch,
+        url=url,
+        license=license_,
+        depends=depends,
+        makedepends=makedepends,
+        optdepends=optdepends,
+        provides=provides,
+        conflicts=conflicts,
+        replaces=replaces,
+        source=source,
+        epoch=epoch,
+    )
+
+    return info, functions
+
+
+def convert_pkgbuild_to_lpmbuild(text: str) -> Tuple[PKGBuildInfo, str]:
+    info, functions = parse_pkgbuild(text)
+
+    version = info.version
+    if info.epoch and info.epoch not in {"", "0"}:
+        version = f"{info.epoch}:{version}"
+
+    arch_value = ""
+    if info.arch:
+        first = info.arch[0]
+        arch_value = "noarch" if first == "any" else first
+
+    requires: List[str] = []
+    seen: Dict[str, None] = {}
+    for dep in info.depends + info.makedepends:
+        if dep not in seen:
+            seen[dep] = None
+            requires.append(dep)
+
+    suggests: List[str] = []
+    for entry in info.optdepends:
+        name = normalize_dependency_name(entry)
+        if name:
+            suggests.append(name)
+
+    lines = ["# Generated by src.arch_compat", _format_scalar("NAME", info.name)]
+    lines.append(_format_scalar("VERSION", version))
+    lines.append(_format_scalar("RELEASE", info.release))
+    if arch_value:
+        lines.append(_format_scalar("ARCH", arch_value))
+    if info.summary:
+        lines.append(_format_scalar("SUMMARY", info.summary))
+    if info.url:
+        lines.append(_format_scalar("URL", info.url))
+    if info.license:
+        lines.append(_format_scalar("LICENSE", ", ".join(info.license)))
+    if requires:
+        lines.append(_format_array("REQUIRES", requires))
+    if info.provides:
+        lines.append(_format_array("PROVIDES", info.provides))
+    if info.conflicts:
+        lines.append(_format_array("CONFLICTS", info.conflicts))
+    if info.replaces:
+        lines.append(_format_array("OBSOLETES", info.replaces))
+    if suggests:
+        lines.append(_format_array("SUGGESTS", suggests))
+    if info.source:
+        lines.append(_format_array("SOURCE", info.source))
+
+    lines.append("")
+
+    prepare_body = _sanitize_body(functions.get("prepare", ""))
+    build_body = _sanitize_body(functions.get("build", ""))
+    check_body = _sanitize_body(functions.get("check", ""))
+    install_body = _sanitize_body(functions.get("package", ""))
+
+    lines.append(_format_function("prepare", prepare_body))
+    lines.append("")
+    lines.append(_format_function("build", build_body))
+    if check_body:
+        lines.append("")
+        lines.append(_format_function("check", check_body))
+    lines.append("")
+    lines.append(_format_function("install", install_body))
+
+    script = "\n".join(lines).rstrip() + "\n"
+    return info, script
+
+
+def _make_pkgbuild_url(base: str, pkgname: str) -> str:
+    return f"{base.rstrip('/')}/{pkgname}/-/raw/main/PKGBUILD"
+
+
+def fetch_pkgbuild(pkgname: str, endpoints: Optional[Mapping[str, str]] = None) -> str:
+    endpoints = dict(endpoints or ARCH_REPO_ENDPOINTS)
+    pkg = pkgname
+    repo: Optional[str] = None
+    if "/" in pkgname:
+        repo, pkg = pkgname.split("/", 1)
+
+    order: List[Tuple[str, str]] = []
+    if repo and repo in endpoints:
+        order.append((repo, endpoints[repo]))
+    for key, base in endpoints.items():
+        if repo and key == repo:
+            continue
+        order.append((key, base))
+
+    errors: List[str] = []
+    for label, base in order:
+        url = _make_pkgbuild_url(base, pkg)
+        try:
+            data = urlread(url)
+            return data.decode("utf-8")
+        except Exception as exc:  # pragma: no cover - errors logged
+            errors.append(f"{label}: {exc}")
+            continue
+    raise RuntimeError(f"Unable to fetch PKGBUILD for {pkgname} (tried {', '.join(label for label, _ in order)})")
+
+
+class PKGBuildConverter:
+    def __init__(
+        self,
+        workspace: Path,
+        *,
+        endpoints: Optional[Mapping[str, str]] = None,
+        fetcher: Optional[Callable[[str], str]] = None,
+    ) -> None:
+        self.workspace = Path(workspace)
+        self.workspace.mkdir(parents=True, exist_ok=True)
+        self.endpoints = dict(endpoints or ARCH_REPO_ENDPOINTS)
+        self._fetcher = fetcher
+        self._scripts: Dict[str, Path] = {}
+        self._meta: Dict[str, PKGBuildInfo] = {}
+        self._in_progress: set[str] = set()
+
+    def convert_text(self, text: str) -> Tuple[PKGBuildInfo, Path]:
+        info, script = convert_pkgbuild_to_lpmbuild(text)
+        path = self.workspace / f"{info.name}.lpmbuild"
+        path.write_text(script, encoding="utf-8")
+        self._scripts[info.name] = path
+        self._meta[info.name] = info
+        return info, path
+
+    def convert_file(self, path: Path) -> Tuple[PKGBuildInfo, Path]:
+        return self.convert_text(path.read_text(encoding="utf-8"))
+
+    def _fetch_remote(self, pkgname: str) -> str:
+        if self._fetcher is not None:
+            return self._fetcher(pkgname)
+        return fetch_pkgbuild(pkgname, self.endpoints)
+
+    def convert_remote(self, pkgname: str) -> Tuple[PKGBuildInfo, Path]:
+        text = self._fetch_remote(pkgname)
+        info, path = self.convert_text(text)
+        for dep in info.dependency_names():
+            if dep != info.name:
+                self.ensure_dependency(dep)
+        return info, path
+
+    def ensure_dependency(self, dep: str) -> Optional[Path]:
+        base = normalize_dependency_name(dep)
+        if not base:
+            return None
+        if base in self._scripts:
+            return self._scripts[base]
+        if base in self._in_progress:
+            return None
+        self._in_progress.add(base)
+        try:
+            text = self._fetch_remote(base)
+        except Exception as exc:
+            logging.warning("Failed to fetch dependency %s: %s", base, exc)
+            self._in_progress.discard(base)
+            return None
+        try:
+            info, path = self.convert_text(text)
+        finally:
+            self._in_progress.discard(base)
+        for child in info.dependency_names():
+            if child != info.name:
+                self.ensure_dependency(child)
+        return path
+
+    def make_fetcher(self) -> Callable[[str, Path], Path]:
+        def _fetch(pkgname: str, dest: Path) -> Path:
+            base = normalize_dependency_name(pkgname) or pkgname
+            path = self._scripts.get(base)
+            if path is None:
+                path = self.ensure_dependency(base)
+            if path is None:
+                raise RuntimeError(f"Unable to convert dependency {pkgname}")
+            if path.resolve() == dest.resolve():
+                return dest
+            shutil.copy2(path, dest)
+            return dest
+
+        return _fetch
+
+    def metadata_for(self, name: str) -> Optional[PKGBuildInfo]:
+        return self._meta.get(name)
+
+
+__all__ = [
+    "PKGBuildInfo",
+    "PKGBuildConverter",
+    "convert_pkgbuild_to_lpmbuild",
+    "fetch_pkgbuild",
+    "normalize_dependency_name",
+    "parse_pkgbuild",
+]

--- a/src/config.py
+++ b/src/config.py
@@ -34,6 +34,17 @@ MARCH = "generic"
 MTUNE = "generic"
 CPU_VENDOR = ""
 CPU_FAMILY = ""
+DEVELOPER_MODE = False
+ARCH_REPO_ENDPOINTS: Dict[str, str] = {}
+
+_ARCH_REPO_DEFAULTS: Dict[str, str] = {
+    "core": "https://gitlab.archlinux.org/archlinux/packaging/packages",
+    "extra": "https://gitlab.archlinux.org/archlinux/packaging/packages",
+    "community": "https://gitlab.archlinux.org/archlinux/packaging/packages",
+    "multilib": "https://gitlab.archlinux.org/archlinux/packaging/packages",
+    "testing": "https://gitlab.archlinux.org/archlinux/packaging/packages",
+    "meta": "https://gitlab.archlinux.org/archlinux/packaging/meta",
+}
 
 
 def initialize_state() -> None:
@@ -65,6 +76,32 @@ def _get_bool(key: str, default: bool) -> bool:
     if val is None:
         return default
     return val.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _load_arch_repo_endpoints(conf: Mapping[str, str]) -> Dict[str, str]:
+    endpoints = dict(_ARCH_REPO_DEFAULTS)
+
+    raw_conf = conf.get("ARCH_REPO_ENDPOINTS")
+    env_conf = os.environ.get("LPM_ARCH_ENDPOINTS")
+    for source in (raw_conf, env_conf):
+        if not source:
+            continue
+        try:
+            parsed = json.loads(source)
+        except json.JSONDecodeError:
+            logging.warning("Invalid ARCH_REPO_ENDPOINTS JSON: %s", source)
+            continue
+        if isinstance(parsed, dict):
+            for key, value in parsed.items():
+                if isinstance(key, str) and isinstance(value, str) and value.strip():
+                    endpoints[key.strip()] = value.strip()
+
+    for key in list(endpoints):
+        override = conf.get(f"ARCH_REPO_{key.upper()}")
+        if override:
+            endpoints[key] = override.strip()
+
+    return endpoints
 
 
 def _detect_cpu() -> Tuple[str, str, str, str]:
@@ -151,7 +188,7 @@ def _init_cpu_settings() -> Tuple[str, str, str, str]:
 def _apply_conf(conf: Mapping[str, str]) -> None:
     global CONF, ARCH, OPT_LEVEL, MAX_SNAPSHOTS, MAX_LEARNT_CLAUSES
     global INSTALL_PROMPT_DEFAULT, ALLOW_LPMBUILD_FALLBACK, MARCH, MTUNE
-    global CPU_VENDOR, CPU_FAMILY
+    global CPU_VENDOR, CPU_FAMILY, DEVELOPER_MODE, ARCH_REPO_ENDPOINTS
 
     CONF = dict(conf)
     ARCH = CONF.get("ARCH", os.uname().machine if hasattr(os, "uname") else "x86_64")
@@ -175,6 +212,14 @@ def _apply_conf(conf: Mapping[str, str]) -> None:
         INSTALL_PROMPT_DEFAULT = "n"
 
     ALLOW_LPMBUILD_FALLBACK = _get_bool("ALLOW_LPMBUILD_FALLBACK", False)
+
+    env_dev = os.environ.get("LPM_DEVELOPER_MODE")
+    if env_dev is not None:
+        DEVELOPER_MODE = env_dev.strip().lower() in {"1", "true", "yes", "on"}
+    else:
+        DEVELOPER_MODE = _get_bool("DEVELOPER_MODE", False)
+
+    ARCH_REPO_ENDPOINTS = _load_arch_repo_endpoints(CONF)
 
     MARCH, MTUNE, CPU_VENDOR, CPU_FAMILY = _init_cpu_settings()
 
@@ -307,5 +352,7 @@ __all__ = [
     "MTUNE",
     "CPU_VENDOR",
     "CPU_FAMILY",
+    "DEVELOPER_MODE",
+    "ARCH_REPO_ENDPOINTS",
     "detect_init_system",
 ]

--- a/tests/test_arch_pkgbuild_compat.py
+++ b/tests/test_arch_pkgbuild_compat.py
@@ -1,0 +1,229 @@
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src import arch_compat
+
+
+PKGBUILD_SAMPLE = """
+# Maintainer: Example
+pkgname=foo
+pkgver=1.2
+pkgrel=3
+pkgdesc="Demo package"
+arch=('any')
+url='https://example.com/foo'
+license=('MIT')
+depends=('bar>=1.0')
+makedepends=('cmake')
+optdepends=('baz:extra tool')
+provides=('foo')
+conflicts=('foo-old')
+replaces=('foo-old')
+source=('foo.tar.gz')
+
+prepare() {
+    pacman -S --noconfirm something
+    echo prepare
+}
+
+build() {
+    echo build
+}
+
+package() {
+    pacman -Rsn something
+    mkdir -p "$pkgdir/usr/bin"
+    echo hi > "$pkgdir/usr/bin/foo"
+}
+"""
+
+
+def test_convert_pkgbuild_strips_pacman_calls():
+    info, script = arch_compat.convert_pkgbuild_to_lpmbuild(PKGBUILD_SAMPLE)
+
+    assert info.name == "foo"
+    assert info.version == "1.2"
+    assert info.release == "3"
+    assert "pacman" not in script
+    assert "REQUIRES=(" in script
+    assert "'bar>=1.0'" in script
+    assert "cmake" in script
+    assert "SUGGESTS=(baz)" in script
+    assert "install()" in script
+    assert "mkdir -p" in script
+    assert info.dependency_names() == ["bar", "cmake"]
+
+
+def test_converter_fetches_dependencies(tmp_path):
+    foo_pkgbuild = """
+    pkgname=foo
+    pkgver=1
+    pkgrel=1
+    pkgdesc='Foo'
+    depends=('bar')
+    makedepends=()
+    build() { :; }
+    package() {
+        mkdir -p "$pkgdir/usr"
+        touch "$pkgdir/usr/foo"
+    }
+    """
+    bar_pkgbuild = """
+    pkgname=bar
+    pkgver=1
+    pkgrel=1
+    pkgdesc='Bar'
+    build() { :; }
+    package() {
+        mkdir -p "$pkgdir/usr"
+        touch "$pkgdir/usr/bar"
+    }
+    """
+
+    registry = {"foo": foo_pkgbuild, "bar": bar_pkgbuild}
+
+    def fake_fetch(name: str) -> str:
+        return registry[name]
+
+    converter = arch_compat.PKGBuildConverter(tmp_path, fetcher=fake_fetch)
+    info, script_path = converter.convert_text(registry["foo"])
+    assert script_path.exists()
+    assert info.dependency_names() == ["bar"]
+
+    fetcher = converter.make_fetcher()
+    dest = tmp_path / "bar.lpmbuild"
+    fetcher("bar", dest)
+    text = dest.read_text(encoding="utf-8")
+    assert "NAME=bar" in text
+    assert "install()" in text
+
+
+def test_meta_package_conversion():
+    meta_pkgbuild = """
+    pkgname=base-devel
+    pkgver=1
+    pkgrel=1
+    pkgdesc='Meta'
+    arch=('any')
+    depends=('gcc' 'make')
+    package() { :; }
+    """
+
+    info, script = arch_compat.convert_pkgbuild_to_lpmbuild(meta_pkgbuild)
+    assert info.dependency_names() == ["gcc", "make"]
+    assert "install()" in script
+    assert "    :" in script
+
+
+def _load_lpm(tmp_path, monkeypatch):
+    root = Path(__file__).resolve().parent.parent
+    monkeypatch.setenv("LPM_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("LPM_DEVELOPER_MODE", "1")
+    for name in ["lpm", "src.config", "src.arch_compat"]:
+        sys.modules.pop(name, None)
+    spec = importlib.util.spec_from_file_location("lpm", root / "lpm.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["lpm"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_buildpkg_from_pkgbuild(tmp_path, monkeypatch):
+    lpm = _load_lpm(tmp_path, monkeypatch)
+    pkgbuild = tmp_path / "PKGBUILD"
+    pkgbuild.write_text(
+        """
+        pkgname=testpkg
+        pkgver=1
+        pkgrel=1
+        pkgdesc='Demo'
+        build() { :; }
+        package() {
+            mkdir -p "$pkgdir/usr/bin"
+            echo hi > "$pkgdir/usr/bin/hi"
+        }
+        """,
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr("builtins.input", lambda *args, **kwargs: "n")
+
+    args = SimpleNamespace(
+        script=pkgbuild,
+        outdir=tmp_path,
+        no_deps=True,
+        install_default="n",
+        from_pkgbuild=True,
+    )
+
+    lpm.cmd_buildpkg(args)
+    produced = list(tmp_path.glob("testpkg-1-1.*.zst"))
+    assert produced
+
+
+def test_pkgbuild_cli_build_with_dependencies(tmp_path, monkeypatch):
+    lpm = _load_lpm(tmp_path, monkeypatch)
+    from src import arch_compat as converter_module  # type: ignore
+
+    foo_pkgbuild = """
+    pkgname=foo
+    pkgver=1
+    pkgrel=1
+    pkgdesc='Foo'
+    depends=('bar')
+    build() { :; }
+    package() {
+        mkdir -p "$pkgdir/usr/bin"
+        echo foo > "$pkgdir/usr/bin/foo"
+    }
+    """
+    bar_pkgbuild = """
+    pkgname=bar
+    pkgver=1
+    pkgrel=1
+    pkgdesc='Bar'
+    build() { :; }
+    package() {
+        mkdir -p "$pkgdir/usr/bin"
+        echo bar > "$pkgdir/usr/bin/bar"
+    }
+    """
+
+    mapping = {"bar": bar_pkgbuild}
+
+    def fake_fetch(name: str, endpoints=None):
+        if name not in mapping:
+            raise RuntimeError(name)
+        return mapping[name]
+
+    monkeypatch.setattr(converter_module, "fetch_pkgbuild", fake_fetch)
+    monkeypatch.setattr("builtins.input", lambda *args, **kwargs: "n")
+
+    source = tmp_path / "PKGBUILD"
+    source.write_text(foo_pkgbuild, encoding="utf-8")
+
+    args = SimpleNamespace(
+        source=str(source),
+        output=tmp_path / "foo.lpmbuild",
+        build=True,
+        install=False,
+        outdir=tmp_path,
+        no_deps=False,
+        install_default="n",
+    )
+
+    lpm.cmd_pkgbuild_to_lpmbuild(args)
+
+    assert args.output.exists()
+    built = list(tmp_path.glob("foo-1-1.*.zst"))
+    assert built
+    dep_pkgs = list(tmp_path.glob("bar-1-1.*.zst"))
+    assert dep_pkgs

--- a/tests/test_run_lpmbuild_progress.py
+++ b/tests/test_run_lpmbuild_progress.py
@@ -26,7 +26,7 @@ def test_cmd_buildpkg_shows_progress_and_summary(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(lpm, "run_lpmbuild", fake_run_lpmbuild)
     monkeypatch.setattr(lpm, "read_package_meta", fake_read_package_meta)
 
-    args = SimpleNamespace(script=script, outdir=tmp_path, no_deps=False, install_default=None)
+    args = SimpleNamespace(script=script, outdir=tmp_path, no_deps=False, install_default=None, from_pkgbuild=False)
     lpm.cmd_buildpkg(args)
 
     captured = capsys.readouterr()


### PR DESCRIPTION
## Summary
- add a developer mode switch and configurable Arch packaging endpoints to the runtime config
- implement an Arch PKGBUILD compatibility module plus developer tooling that converts PKGBUILDs, fetches dependencies, and wires buildpkg to use it
- add regression tests covering PKGBUILD conversion, dependency conversion, and developer-mode build flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd8f43ee60832789bd96f289298990