### PR TITLE
Add developer tar export for Arch PKGBUILDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,34 @@ contents and runs common maintenance commands based on what it finds:
   – build an `.lpm` package from a staged root.
 - `lpm buildpkg SCRIPT [--outdir PATH] [--no-deps]` – run a `.lpmbuild` script to
   produce a package.
+- `lpm pkgbuild-export-tar OUTPUT TARGET... [--workspace DIR]` – developer mode
+  helper that fetches Arch Linux PKGBUILDs, converts them to `.lpmbuild`
+  scripts (including dependencies), stages them under `packages/<name>` and
+  writes the result to an archive at `OUTPUT`. `TARGET` entries can be package
+  names such as `extra/zstd` or paths/URLs to repository `index.json` files.
 - `lpm genindex REPO_DIR [--base-url URL] [--arch ARCH]` – generate an
   `index.json` for a directory of packages.
 - `lpm installpkg FILE... [--root PATH] [--dry-run] [--verify] [--force]`
   – install from local package files.
 - `lpm removepkg NAME... [--root PATH] [--dry-run] [--force]` – remove installed
   packages by name.
+
+#### Exporting Arch PKGBUILDs
+
+When `LPM_DEVELOPER_MODE=1` the `pkgbuild-export-tar` command can bootstrap a
+local `.lpmbuild` workspace straight from Arch Linux packaging sources. Provide
+one or more package names (optionally prefixed with their repository) or
+existing repository `index.json` files and an output archive path:
+
+```
+LPM_DEVELOPER_MODE=1 lpm pkgbuild-export-tar arch-export.tar foo extra/zstd repo/index.json
+```
+
+LPM fetches each PKGBUILD from `gitlab.archlinux.org`, converts it to
+`.lpmbuild`, resolves meta-package dependencies through the same converter, and
+stages the results under `packages/<name>/<name>.lpmbuild` before writing the
+tarball. The optional `--workspace DIR` flag reuses a conversion cache so
+subsequent exports only download new packages.
 
 #### Symlink manifest digests
 

--- a/src/arch_compat.py
+++ b/src/arch_compat.py
@@ -397,6 +397,12 @@ class PKGBuildConverter:
     def metadata_for(self, name: str) -> Optional[PKGBuildInfo]:
         return self._meta.get(name)
 
+    def iter_scripts(self) -> Iterable[tuple[str, Path]]:
+        """Yield ``(name, path)`` pairs for all converted packages."""
+
+        for name, path in self._scripts.items():
+            yield name, path
+
 
 __all__ = [
     "PKGBuildInfo",

--- a/tests/test_pkgbuild_export_tar.py
+++ b/tests/test_pkgbuild_export_tar.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tarfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def _load_lpm(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    root = Path(__file__).resolve().parent.parent
+    monkeypatch.setenv("LPM_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("LPM_DEVELOPER_MODE", "1")
+    for name in ["lpm", "src.config", "src.arch_compat"]:
+        sys.modules.pop(name, None)
+    spec = importlib.util.spec_from_file_location("lpm", root / "lpm.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["lpm"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_pkgbuild_export_tarball(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    lpm = _load_lpm(tmp_path, monkeypatch)
+
+    pkgbuilds = {
+        "foo": """
+            pkgname=foo
+            pkgver=1
+            pkgrel=1
+            pkgdesc='Foo'
+            depends=('bar')
+            build() { :; }
+            package() {
+                mkdir -p "$pkgdir/usr/bin"
+                echo foo > "$pkgdir/usr/bin/foo"
+            }
+        """,
+        "bar": """
+            pkgname=bar
+            pkgver=1
+            pkgrel=1
+            pkgdesc='Bar'
+            build() { :; }
+            package() {
+                mkdir -p "$pkgdir/usr/bin"
+                echo bar > "$pkgdir/usr/bin/bar"
+            }
+        """,
+        "meta-pkg": """
+            pkgname=meta-pkg
+            pkgver=1
+            pkgrel=1
+            pkgdesc='Meta'
+            arch=('any')
+            depends=('foo' 'baz')
+            package() { :; }
+        """,
+        "baz": """
+            pkgname=baz
+            pkgver=1
+            pkgrel=1
+            pkgdesc='Baz'
+            build() { :; }
+            package() {
+                mkdir -p "$pkgdir/usr/bin"
+                echo baz > "$pkgdir/usr/bin/baz"
+            }
+        """,
+    }
+
+    def fake_fetch(name: str, endpoints=None):
+        if name not in pkgbuilds:
+            raise RuntimeError(name)
+        return pkgbuilds[name]
+
+    monkeypatch.setattr("src.arch_compat.fetch_pkgbuild", fake_fetch)
+
+    index_path = tmp_path / "index.json"
+    index_path.write_text(json.dumps({"packages": [{"name": "meta-pkg"}]}), encoding="utf-8")
+
+    out_tar = tmp_path / "export.tar"
+    args = SimpleNamespace(output=out_tar, targets=["foo", str(index_path)], workspace=None)
+
+    lpm.cmd_pkgbuild_export_tar(args)
+
+    assert out_tar.exists()
+
+    with tarfile.open(out_tar, "r") as tf:
+        members = {m.name for m in tf.getmembers()}
+        expected = {
+            "packages",
+            "packages/foo",
+            "packages/foo/foo.lpmbuild",
+            "packages/bar",
+            "packages/bar/bar.lpmbuild",
+            "packages/meta-pkg",
+            "packages/meta-pkg/meta-pkg.lpmbuild",
+            "packages/baz",
+            "packages/baz/baz.lpmbuild",
+        }
+        assert expected.issubset(members)
+
+        meta_file = tf.extractfile("packages/meta-pkg/meta-pkg.lpmbuild")
+        assert meta_file is not None
+        meta_text = meta_file.read().decode("utf-8")
+        assert "NAME=meta-pkg" in meta_text
+        assert "install()" in meta_text
+        assert "    :" in meta_text
+
+        foo_file = tf.extractfile("packages/foo/foo.lpmbuild")
+        assert foo_file is not None
+        foo_text = foo_file.read().decode("utf-8")
+        assert "REQUIRES=(bar" in foo_text


### PR DESCRIPTION
## Summary
- add a developer-mode `pkgbuild-export-tar` CLI that fetches Arch PKGBUILDs, converts them with existing compatibility code, stages the results under `packages/<name>` and archives them
- expose converted script paths from `PKGBuildConverter` and document the new workflow in the README
- add regression coverage to ensure the tarball layout contains main packages, dependencies and meta packages

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd946a2d748327bb2aba82ed8b0f7e