### PR TITLE
Add runtime metadata for LPM

### DIFF
--- a/lpm.py
+++ b/lpm.py
@@ -25,33 +25,45 @@ from collections import deque
 import zstandard as zstd
 
 # =========================== Runtime metadata =================================
+_ENV_NAME = "LPM_NAME"
 _ENV_VERSION = "LPM_VERSION"
 _ENV_BUILD = "LPM_BUILD"
 _ENV_BUILD_DATE = "LPM_BUILD_DATE"
+_ENV_DEVELOPER = "LPM_DEVELOPER"
+_ENV_URL = "LPM_URL"
 
-_DEFAULT_VERSION = "0.0.0"
+_DEFAULT_NAME = "LPM"
+_DEFAULT_VERSION = "0.9.19.25-beta"
 _DEFAULT_BUILD = "development"
 _DEFAULT_BUILD_DATE = ""
+_DEFAULT_DEVELOPER = "Derek Midkiff aka BobTheZombie"
+_DEFAULT_URL = "https://github.com/BobTheZombie/LPM"
 
+__title__ = os.environ.get(_ENV_NAME, _DEFAULT_NAME)
 __version__ = os.environ.get(_ENV_VERSION, _DEFAULT_VERSION)
 __build__ = os.environ.get(_ENV_BUILD, _DEFAULT_BUILD)
 __build_date__ = os.environ.get(_ENV_BUILD_DATE, _DEFAULT_BUILD_DATE)
+__developer__ = os.environ.get(_ENV_DEVELOPER, _DEFAULT_DEVELOPER)
+__url__ = os.environ.get(_ENV_URL, _DEFAULT_URL)
 
 
 def get_runtime_metadata() -> Dict[str, str]:
     """Return runtime metadata describing the current LPM build.
 
-    The module level ``__version__``, ``__build__``, and ``__build_date__``
-    constants default to static fallback values but can be overridden via the
-    ``LPM_VERSION``, ``LPM_BUILD``, and ``LPM_BUILD_DATE`` environment
-    variables. Importing :mod:`lpm` merely exposes these values without
-    triggering the heavier initialization logic below.
+    The module level ``__title__``, ``__version__``, ``__build__``,
+    ``__build_date__``, ``__developer__``, and ``__url__`` constants default to
+    static fallback values but can be overridden via the corresponding
+    ``LPM_*`` environment variables. Importing :mod:`lpm` merely exposes these
+    values without triggering the heavier initialization logic below.
     """
 
     return {
+        "name": __title__,
         "version": __version__,
         "build": __build__,
         "build_date": __build_date__,
+        "developer": __developer__,
+        "url": __url__,
     }
 
 from src.config import (

--- a/src/first_run_ui.py
+++ b/src/first_run_ui.py
@@ -128,10 +128,17 @@ def _print_header(out: TextIO, metadata: Mapping[str, str], init_system: str, cp
         "for any setting. You can re-run it later with 'lpm setup'.\n\n"
     )
     out.write("Runtime metadata:\n")
+    out.write(f"  Name       : {metadata.get('name', 'unknown')}\n")
     out.write(f"  Version    : {metadata.get('version', 'unknown')}\n")
     out.write(f"  Build      : {metadata.get('build', 'development')}\n")
     build_date = metadata.get("build_date") or "unknown"
     out.write(f"  Build date : {build_date}\n")
+    developer = metadata.get("developer")
+    if developer:
+        out.write(f"  Developer  : {developer}\n")
+    project_url = metadata.get("url")
+    if project_url:
+        out.write(f"  Project URL: {project_url}\n")
     out.write("\n")
     out.write(f"Detected init system : {init_system}\n")
     out.write(

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -58,32 +58,47 @@ def import_lpm():
 
 
 def test_get_runtime_metadata_defaults(monkeypatch, import_lpm):
+    monkeypatch.delenv("LPM_NAME", raising=False)
     monkeypatch.delenv("LPM_VERSION", raising=False)
     monkeypatch.delenv("LPM_BUILD", raising=False)
     monkeypatch.delenv("LPM_BUILD_DATE", raising=False)
+    monkeypatch.delenv("LPM_DEVELOPER", raising=False)
+    monkeypatch.delenv("LPM_URL", raising=False)
 
     mod = import_lpm()
     metadata = mod.get_runtime_metadata()
 
-    assert set(metadata) == {"version", "build", "build_date"}
+    assert set(metadata) == {"name", "version", "build", "build_date", "developer", "url"}
+    assert metadata["name"] == mod.__title__
     assert metadata["version"] == mod.__version__
     assert metadata["build"] == mod.__build__
     assert metadata["build_date"] == mod.__build_date__
+    assert metadata["developer"] == mod.__developer__
+    assert metadata["url"] == mod.__url__
 
 
 def test_get_runtime_metadata_env_override(monkeypatch, import_lpm):
+    monkeypatch.setenv("LPM_NAME", "Custom LPM")
     monkeypatch.setenv("LPM_VERSION", "1.2.3")
     monkeypatch.setenv("LPM_BUILD", "abc123")
     monkeypatch.setenv("LPM_BUILD_DATE", "2024-01-02T03:04:05Z")
+    monkeypatch.setenv("LPM_DEVELOPER", "Jane Doe")
+    monkeypatch.setenv("LPM_URL", "https://example.com/lpm")
 
     mod = import_lpm()
     metadata = mod.get_runtime_metadata()
 
     assert metadata == {
+        "name": "Custom LPM",
         "version": "1.2.3",
         "build": "abc123",
         "build_date": "2024-01-02T03:04:05Z",
+        "developer": "Jane Doe",
+        "url": "https://example.com/lpm",
     }
+    assert mod.__title__ == "Custom LPM"
     assert mod.__version__ == "1.2.3"
     assert mod.__build__ == "abc123"
     assert mod.__build_date__ == "2024-01-02T03:04:05Z"
+    assert mod.__developer__ == "Jane Doe"
+    assert mod.__url__ == "https://example.com/lpm"


### PR DESCRIPTION
## Summary
- expose LPM metadata constants including name, version, developer, and project URL with environment overrides
- surface the expanded metadata through the runtime helper and first-run setup UI
- extend metadata unit tests to cover the new fields and environment overrides

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cda7f07f8c83278a1d504f736fb10c