### PR TITLE
Add split package support from lpmbuild scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ contents and runs common maintenance commands based on what it finds:
   [--provides PKG ...] [--conflicts PKG ...] [--obsoletes PKG ...]
   [--recommends PKG ...] [--suggests PKG ...] [--output FILE] [--no-sign]`
   – build a `.zst` package from a staged root.
+- `lpm splitpkg --stagedir DIR [--name NAME] [--version VERSION] [--release N]`
+  `[--arch ARCH] [--summary TEXT] [--requires PKG ...] [--provides PKG ...]`
+  `[--conflicts PKG ...] [--obsoletes PKG ...] [--recommends PKG ...]`
+  `[--suggests PKG ...] [--outdir DIR] [--output FILE] [--no-sign]` – package an
+  additional staged root (for split packages) using the metadata gathered from
+  the parent `.lpmbuild`.
 - `lpm buildpkg SCRIPT [--outdir PATH] [--no-deps]` – run a `.lpmbuild` script to
   produce a package.
 - `lpm pkgbuild-export-tar OUTPUT TARGET... [--workspace DIR]` – developer mode

--- a/docs/TECHNICAL-HOWTO.md
+++ b/docs/TECHNICAL-HOWTO.md
@@ -348,6 +348,22 @@ Meson-style summary with build time and dependency count when it finishes.【F:l
 $ lpm buildpkg packages/hello/hello.lpmbuild --outdir dist
 ```
 
+During the `install` phase the script can emit extra packages by calling the
+`LPM_SPLIT_PACKAGE` helper. The environment variable points to a tiny wrapper
+around `lpm splitpkg` that reuses the metadata collected from the parent
+package. Supply a staged root and any metadata overrides to produce a
+fully-signed package inline, for example:
+
+```bash
+splitdir="$BUILDROOT/gcc-fortran"
+mkdir -p "$splitdir/usr/bin"
+cp fortran/* "$splitdir/usr/bin/"
+"$LPM_SPLIT_PACKAGE" --stagedir "$splitdir" --name gcc-fortran --requires gcc-libs
+```
+
+Each invocation writes the package to the current build output directory and is
+reported alongside the primary package when the build completes.【F:lpm.py†L1833-L1894】【F:lpm.py†L2405-L2445】
+
 ### 10.3 `lpm genindex`
 
 Generates an `index.json` for a repository directory full of `.zst` archives.

--- a/tests/test_buildpkg_no_deps.py
+++ b/tests/test_buildpkg_no_deps.py
@@ -85,7 +85,7 @@ def test_run_lpmbuild_defaults_missing_arch(tmp_path, monkeypatch):
     sys.modules["lpm"] = lpm
     spec.loader.exec_module(lpm)
 
-    built, _, _ = lpm.run_lpmbuild(
+    built, _, _, splits = lpm.run_lpmbuild(
         script,
         outdir=tmp_path,
         prompt_install=False,
@@ -96,3 +96,4 @@ def test_run_lpmbuild_defaults_missing_arch(tmp_path, monkeypatch):
 
     meta, _ = lpm.read_package_meta(built)
     assert meta.arch == lpm.ARCH
+    assert splits == []

--- a/tests/test_run_lpmbuild_install_script.py
+++ b/tests/test_run_lpmbuild_install_script.py
@@ -55,10 +55,11 @@ def test_run_lpmbuild_defaults_arch_to_noarch(tmp_path, monkeypatch):
 
     monkeypatch.setattr(lpm, "build_package", fake_build_package)
 
-    out_path, _, _ = lpm.run_lpmbuild(script, outdir=tmp_path, prompt_install=False, build_deps=False)
+    out_path, _, _, splits = lpm.run_lpmbuild(script, outdir=tmp_path, prompt_install=False, build_deps=False)
 
     assert recorded["meta_arch"] == lpm.PkgMeta.__dataclass_fields__["arch"].default
     assert out_path.name.endswith(".zst")
     assert ".." not in out_path.name
+    assert splits == []
 
     shutil.rmtree(recorded["stagedir"])

--- a/tests/test_run_lpmbuild_progress.py
+++ b/tests/test_run_lpmbuild_progress.py
@@ -17,7 +17,7 @@ def test_cmd_buildpkg_shows_progress_and_summary(monkeypatch, tmp_path, capsys):
             print(f"[{i}/3] {phase}", file=sys.stderr)
         out = (outdir or script.parent) / "foo-1-1.noarch.zst"
         out.write_text("dummy")
-        return out, 1.0, 3
+        return out, 1.0, 3, []
 
     def fake_read_package_meta(path):
         meta = PkgMeta(name="foo", version="1", release="1", arch="noarch", summary="demo")

--- a/tests/test_split_packages.py
+++ b/tests/test_split_packages.py
@@ -1,0 +1,58 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import lpm
+
+
+def test_run_lpmbuild_creates_split_packages(tmp_path, monkeypatch):
+    monkeypatch.setenv("LPM_STATE_DIR", str(tmp_path / "state"))
+
+    script = tmp_path / "split.lpmbuild"
+    script.write_text(
+        "\n".join(
+            [
+                "NAME=foo",
+                "VERSION=1.2.3",
+                "RELEASE=2",
+                "ARCH=noarch",
+                "SUMMARY=\"Base package\"",
+                "prepare(){ :; }",
+                "build(){ :; }",
+                "install(){",
+                "  mkdir -p \"$pkgdir/usr/bin\"",
+                "  echo base > \"$pkgdir/usr/bin/foo\"",
+                "  split_a=\"$BUILDROOT/split-a\"",
+                "  mkdir -p \"$split_a/usr/bin\"",
+                "  echo alpha > \"$split_a/usr/bin/foo-alpha\"",
+                "  $LPM_SPLIT_PACKAGE --stagedir \"$split_a\" --name foo-alpha --summary 'Alpha compiler' --requires bar",
+                "  split_b=\"$BUILDROOT/split-b\"",
+                "  mkdir -p \"$split_b/usr/bin\"",
+                "  echo beta > \"$split_b/usr/bin/foo-beta\"",
+                "  $LPM_SPLIT_PACKAGE --stagedir \"$split_b\" --name foo-beta --provides foo-beta-bin",
+                "}",
+            ]
+        )
+    )
+
+    out_path, _, _, splits = lpm.run_lpmbuild(
+        script,
+        outdir=tmp_path,
+        prompt_install=False,
+        build_deps=False,
+    )
+
+    assert out_path.exists()
+    assert len(splits) == 2
+    names = sorted(meta.name for _, meta in splits)
+    assert names == ["foo-alpha", "foo-beta"]
+    for path, meta in splits:
+        assert path.exists()
+        assert meta.version == "1.2.3"
+        assert meta.release == "2"
+        if meta.name == "foo-alpha":
+            assert meta.requires == ["bar"]
+            assert meta.summary == "Alpha compiler"
+        if meta.name == "foo-beta":
+            assert meta.provides == ["foo-beta-bin"]


### PR DESCRIPTION
## Summary
- extend `run_lpmbuild` to expose a split-package helper, record secondary artifacts, and return them to callers
- add a `splitpkg` CLI subcommand plus documentation for invoking it from `.lpmbuild` scripts
- cover the new behaviour with a dedicated split-package test and update existing tests for the expanded return signature

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ceb42e26848327889b14bd7d9b2064