### PR TITLE
Add caching for downloaded sources

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -13,6 +13,7 @@ TEMPLATE_CONF = Path(__file__).resolve().parent.parent / "etc" / "lpm" / "lpm.co
 STATE_DIR = Path(os.environ.get("LPM_STATE_DIR", "/var/lib/lpm"))
 DB_PATH   = STATE_DIR / "state.db"
 CACHE_DIR = STATE_DIR / "cache"
+SOURCE_CACHE_DIR = CACHE_DIR / "sources"
 SNAPSHOT_DIR = STATE_DIR / "snapshots"
 REPO_LIST = STATE_DIR / "repos.json"       # [{"name":"core","url":"file:///srv/repo","priority":10}, ...]
 PIN_FILE  = STATE_DIR / "pins.json"        # {"hold":["pkg"], "prefer":{"pkg":"~=3.3"}}
@@ -49,7 +50,7 @@ _ARCH_REPO_DEFAULTS: Dict[str, str] = {
 
 def initialize_state() -> None:
     os.umask(UMASK)
-    for d in (STATE_DIR, CACHE_DIR, SNAPSHOT_DIR):
+    for d in (STATE_DIR, CACHE_DIR, SOURCE_CACHE_DIR, SNAPSHOT_DIR):
         d.mkdir(parents=True, exist_ok=True)
     if not REPO_LIST.exists():
         REPO_LIST.write_text("[]", encoding="utf-8")

--- a/tests/test_clean_cache.py
+++ b/tests/test_clean_cache.py
@@ -1,9 +1,13 @@
 import sys, importlib
+from pathlib import Path
 from types import SimpleNamespace
 
 
 def _import_lpm(tmp_path, monkeypatch):
     monkeypatch.setenv("LPM_STATE_DIR", str(tmp_path/"state"))
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
     for mod in ["lpm", "src.config"]:
         if mod in sys.modules:
             del sys.modules[mod]

--- a/tests/test_source_cache.py
+++ b/tests/test_source_cache.py
@@ -1,0 +1,48 @@
+import importlib
+import sys
+from pathlib import Path
+
+
+def _import_lpm(tmp_path, monkeypatch):
+    monkeypatch.setenv("LPM_STATE_DIR", str(tmp_path / "state"))
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    for mod in ["lpm", "src.config"]:
+        if mod in sys.modules:
+            del sys.modules[mod]
+    return importlib.import_module("lpm")
+
+
+def test_maybe_fetch_source_uses_cache(tmp_path, monkeypatch):
+    lpm = _import_lpm(tmp_path, monkeypatch)
+    calls = {"count": 0}
+
+    def fake_urlread(url):
+        calls["count"] += 1
+        return b"payload"
+
+    monkeypatch.setattr(lpm, "urlread", fake_urlread)
+    monkeypatch.setattr(lpm, "ok", lambda msg: None)
+    monkeypatch.setattr(lpm, "warn", lambda msg: None)
+
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    url = "https://example.com/sources/foo.tar.gz"
+
+    lpm._maybe_fetch_source(url, src_dir)
+    dst = src_dir / "foo.tar.gz"
+    assert dst.exists()
+    assert dst.read_bytes() == b"payload"
+    assert calls["count"] == 1
+
+    dst.unlink()
+
+    lpm._maybe_fetch_source(url, src_dir)
+    assert dst.exists()
+    assert dst.read_bytes() == b"payload"
+    assert calls["count"] == 1
+
+    cache_files = list(Path(lpm.SOURCE_CACHE_DIR).glob("foo.tar-*.gz"))
+    assert cache_files, "cached source should exist"
+    assert cache_files[0].read_bytes() == b"payload"


### PR DESCRIPTION
## Summary
- add a cache directory for downloaded sources and reuse cached files when available
- ensure the state initialization prepares the source cache and adjust test helpers for reliable imports
- add a regression test covering cached source reuse

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf6c5cfc6083279a76ad08f430d341