### PR TITLE
Call service cleanup once after manifest processing

### DIFF
--- a/lpm.py
+++ b/lpm.py
@@ -1471,8 +1471,9 @@ def _remove_installed_package(meta: dict, root: Path, dry_run: bool, conn):
                     pass
         except Exception as e:
             warn(f"rm {p}: {e}")
-            
-        # Stop/disable/init cleanup for services
+
+    # Stop/disable/init cleanup for services once all files are handled
+    if manifest_entries:
         remove_service_files(name, root, manifest_entries)
  
 


### PR DESCRIPTION
## Summary
- ensure `_remove_installed_package` only triggers service cleanup after all manifest entries are processed
- extend service file tests with module shims and a regression to confirm systemd units are disabled only once

## Testing
- pytest tests/test_service_files.py

------
https://chatgpt.com/codex/tasks/task_e_68cf85bc30f88327bf785de1da22ffd1