### PR TITLE
Resolve SOURCE entries relative to LPMBUILD_REPO

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,11 @@ contents and runs common maintenance commands based on what it finds:
   additional staged root (for split packages) using the metadata gathered from
   the parent `.lpmbuild`.
 - `lpm buildpkg SCRIPT [--outdir PATH] [--no-deps]` – run a `.lpmbuild` script to
-  produce a package.
+  produce a package. `.lpmbuild` scripts may declare a `SOURCE=()` array; entries
+  without a URL scheme automatically resolve to
+  `{LPMBUILD_REPO}/{pkgname}/{filename}`, matching Arch Linux's `source=()`
+  behaviour, while explicit URLs and `foo::https://example.com/src` rename
+  syntax are honoured as-is.【F:lpm.py†L1994-L2018】
 - `lpm pkgbuild-export-tar OUTPUT TARGET... [--workspace DIR]` – developer mode
   helper that fetches Arch Linux PKGBUILDs, converts them to `.lpmbuild`
   scripts (including dependencies), stages them under `packages/<name>` and

--- a/tests/test_run_lpmbuild_sources.py
+++ b/tests/test_run_lpmbuild_sources.py
@@ -1,0 +1,153 @@
+import importlib
+import shutil
+import sys
+import textwrap
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _import_lpm(tmp_path, monkeypatch):
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+
+    for name in ("zstandard", "tqdm"):
+        if name not in sys.modules:
+            module = types.ModuleType(name)
+            if name == "zstandard":
+                class _DummyCompressor:
+                    def stream_writer(self, fh):
+                        return fh
+
+                class _DummyDecompressor:
+                    def stream_reader(self, fh):
+                        return fh
+
+                module.ZstdCompressor = _DummyCompressor
+                module.ZstdDecompressor = _DummyDecompressor
+            else:
+                class _DummyTqdm:
+                    def __init__(self, iterable=None, total=None, **kwargs):
+                        self.iterable = iterable or []
+                        self.total = total
+                        self.n = 0
+
+                    def __iter__(self):
+                        for item in self.iterable or []:
+                            self.n += 1
+                            yield item
+
+                    def update(self, n=1):
+                        self.n += n
+
+                    def set_description(self, _desc):
+                        return None
+
+                    def __enter__(self):
+                        return self
+
+                    def __exit__(self, exc_type, exc, tb):
+                        return False
+
+                module.tqdm = _DummyTqdm  # type: ignore[attr-defined]
+
+            sys.modules[name] = module
+
+    for mod in ("lpm", "src.config"):
+        if mod in sys.modules:
+            del sys.modules[mod]
+
+    monkeypatch.setenv("LPM_STATE_DIR", str(tmp_path / "state"))
+    return importlib.import_module("lpm")
+
+
+@pytest.fixture
+def lpm_module(tmp_path, monkeypatch):
+    return _import_lpm(tmp_path, monkeypatch)
+
+
+def _stub_build_pipeline(lpm, monkeypatch):
+    monkeypatch.setattr(lpm, "sandboxed_run", lambda *args, **kwargs: None)
+    monkeypatch.setattr(lpm, "generate_install_script", lambda stagedir: "echo hi")
+
+    def fake_build_package(stagedir, meta, out, sign=True):
+        out.write_bytes(b"pkg")
+
+    monkeypatch.setattr(lpm, "build_package", fake_build_package)
+
+
+def test_run_lpmbuild_fetches_relative_sources(lpm_module, tmp_path, monkeypatch):
+    lpm = lpm_module
+    script = tmp_path / "foo.lpmbuild"
+    script.write_text(
+        textwrap.dedent(
+            """
+            NAME=foo
+            VERSION=1
+            RELEASE=1
+            ARCH=noarch
+            SOURCE=(
+              'https://example.com/dist/foo-1.tar.gz'
+              'patch.diff'
+            )
+            prepare() { :; }
+            build() { :; }
+            install() { :; }
+            """
+        )
+    )
+
+    _stub_build_pipeline(lpm, monkeypatch)
+    monkeypatch.setattr(lpm, "ok", lambda msg: None)
+    monkeypatch.setattr(lpm, "warn", lambda msg: None)
+
+    base_repo = "https://repo.example/packages"
+    monkeypatch.setitem(lpm.CONF, "LPMBUILD_REPO", base_repo)
+
+    fetched_urls: list[str] = []
+
+    def fake_urlread(url, timeout=10):
+        fetched_urls.append(url)
+        return b"payload"
+
+    monkeypatch.setattr(lpm, "urlread", fake_urlread)
+
+    out_path, _, _, _ = lpm.run_lpmbuild(
+        script,
+        outdir=tmp_path,
+        prompt_install=False,
+        build_deps=False,
+    )
+
+    assert out_path.exists()
+    srcroot = Path("/tmp/src-foo")
+    assert (srcroot / "foo-1.tar.gz").read_bytes() == b"payload"
+    assert (srcroot / "patch.diff").read_bytes() == b"payload"
+
+    expected_repo_url = f"{base_repo}/foo/patch.diff"
+    assert "https://example.com/dist/foo-1.tar.gz" in fetched_urls
+    assert expected_repo_url in fetched_urls
+
+    out_path.unlink()
+    for suffix in ("pkg-foo", "build-foo", "src-foo"):
+        shutil.rmtree(Path(f"/tmp/{suffix}"), ignore_errors=True)
+
+
+def test_maybe_fetch_source_skips_existing_file(lpm_module, tmp_path, monkeypatch):
+    lpm = lpm_module
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+
+    target = src_dir / "already.patch"
+    target.write_text("present", encoding="utf-8")
+
+    def fake_urlread(url, timeout=10):
+        raise AssertionError("should not refetch existing sources")
+
+    monkeypatch.setattr(lpm, "urlread", fake_urlread)
+
+    lpm._maybe_fetch_source("https://example.com/already.patch", src_dir, filename="already.patch")
+
+    assert target.read_text(encoding="utf-8") == "present"


### PR DESCRIPTION
## Summary
- allow `_maybe_fetch_source` to accept an explicit filename so cached or existing sources can be reused without refetching
- resolve `.lpmbuild` SOURCE entries without a scheme against the configured LPMBUILD_REPO and copy local fallbacks when available
- document the new SOURCE handling and add regression tests covering remote and relative entries

## Testing
- pytest tests/test_source_cache.py tests/test_run_lpmbuild_sources.py tests/test_run_lpmbuild_dependencies.py

------
https://chatgpt.com/codex/tasks/task_e_68cf893d0dc883278a457872503f4242