### PR TITLE
Handle missing sys.executable for split helper

### DIFF
--- a/tests/test_split_packages.py
+++ b/tests/test_split_packages.py
@@ -1,14 +1,89 @@
+import contextlib
+import importlib
+import os
+import shlex
 import sys
+import textwrap
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-
-import lpm
+import pytest
 
 
-def test_run_lpmbuild_creates_split_packages(tmp_path, monkeypatch):
+def _write_stub_modules(stub_dir: Path) -> None:
+    stub_dir.mkdir(parents=True, exist_ok=True)
+    (stub_dir / "zstandard.py").write_text(
+        textwrap.dedent(
+            """
+            class ZstdCompressor:
+                def stream_writer(self, fh):
+                    return fh
+
+            class ZstdDecompressor:
+                def stream_reader(self, fh):
+                    return fh
+            """
+        ),
+        encoding="utf-8",
+    )
+    (stub_dir / "tqdm.py").write_text(
+        textwrap.dedent(
+            """
+            class tqdm:
+                def __init__(self, iterable=None, **kwargs):
+                    self.iterable = iterable or []
+                    self.total = kwargs.get("total")
+                    self.desc = kwargs.get("desc")
+                    self.n = 0
+
+                def __iter__(self):
+                    for item in self.iterable:
+                        self.n += 1
+                        yield item
+
+                def update(self, n=1):
+                    self.n += n
+
+                def set_description(self, desc):
+                    self.desc = desc
+
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, exc_type, exc, tb):
+                    return False
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+def _import_lpm(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+
+    stub_dir = tmp_path / "stubs"
+    _write_stub_modules(stub_dir)
+
+    existing_pythonpath = os.environ.get("PYTHONPATH", "")
+    new_pythonpath = os.pathsep.join(filter(None, [str(stub_dir), existing_pythonpath]))
+    monkeypatch.setenv("PYTHONPATH", new_pythonpath)
+    if str(stub_dir) not in sys.path:
+        sys.path.insert(0, str(stub_dir))
+
+    for mod in ("zstandard", "tqdm", "lpm", "src.config"):
+        sys.modules.pop(mod, None)
+
+    return importlib.import_module("lpm")
+
+
+@pytest.fixture
+def lpm_module(tmp_path, monkeypatch):
     monkeypatch.setenv("LPM_STATE_DIR", str(tmp_path / "state"))
+    return _import_lpm(tmp_path, monkeypatch)
 
+
+def test_run_lpmbuild_creates_split_packages(tmp_path, lpm_module):
     script = tmp_path / "split.lpmbuild"
     script.write_text(
         "\n".join(
@@ -36,7 +111,7 @@ def test_run_lpmbuild_creates_split_packages(tmp_path, monkeypatch):
         )
     )
 
-    out_path, _, _, splits = lpm.run_lpmbuild(
+    out_path, _, _, splits = lpm_module.run_lpmbuild(
         script,
         outdir=tmp_path,
         prompt_install=False,
@@ -56,3 +131,58 @@ def test_run_lpmbuild_creates_split_packages(tmp_path, monkeypatch):
             assert meta.summary == "Alpha compiler"
         if meta.name == "foo-beta":
             assert meta.provides == ["foo-beta-bin"]
+
+
+def test_split_package_helper_falls_back_to_argv0(tmp_path, monkeypatch, lpm_module):
+    script = tmp_path / "split.lpmbuild"
+    script.write_text(
+        "\n".join(
+            [
+                "NAME=foo",
+                "VERSION=1.0.0",
+                "RELEASE=1",
+                "ARCH=noarch",
+                "SUMMARY=\"Base package\"",
+                "prepare(){ :; }",
+                "build(){ :; }",
+                "install(){",
+                "  mkdir -p \"$pkgdir/usr/bin\"",
+                "  echo base > \"$pkgdir/usr/bin/foo\"",
+                "}",
+            ]
+        )
+    )
+
+    fallback_binary = tmp_path / "fake-lpm"
+    fallback_binary.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fallback_binary.chmod(0o755)
+
+    missing_executable = tmp_path / "missing-python"
+    monkeypatch.setattr(sys, "executable", str(missing_executable))
+    monkeypatch.setattr(sys, "argv", [str(fallback_binary)] + sys.argv[1:])
+
+    helper_path = Path("/tmp/build-foo/lpm-split-package")
+    original_unlink = Path.unlink
+    with contextlib.suppress(FileNotFoundError):
+        original_unlink(helper_path)
+
+    def fake_unlink(self, *args, **kwargs):
+        if self == helper_path:
+            return None
+        return original_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fake_unlink)
+
+    lpm_module.run_lpmbuild(
+        script,
+        outdir=tmp_path,
+        prompt_install=False,
+        build_deps=False,
+    )
+
+    helper_contents = helper_path.read_text(encoding="utf-8")
+    expected = shlex.quote(str(fallback_binary.resolve()))
+    assert expected in helper_contents
+    assert str(missing_executable) not in helper_contents
+
+    original_unlink(helper_path)


### PR DESCRIPTION
## Summary
- resolve the helper command path when creating lpm-split-package, falling back to argv[0] when sys.executable is missing or in frozen builds
- add regression coverage that simulates the missing executable scenario and stubs required third-party modules

## Testing
- pytest tests/test_split_packages.py

------
https://chatgpt.com/codex/tasks/task_e_68cff649bdd48327b3f4ceddb5d1237d