### PR TITLE
Allow alias sources to resolve to repo URLs

### DIFF
--- a/lpm.py
+++ b/lpm.py
@@ -2054,7 +2054,17 @@ def run_lpmbuild(
             source_ref = source_ref.strip()
 
         parsed = urllib.parse.urlparse(source_ref)
-        if not parsed.scheme and not alias and not os.path.isabs(source_ref):
+
+        if not parsed.scheme and not os.path.isabs(source_ref):
+            local_candidate = (script_dir / source_ref).resolve()
+            if local_candidate.exists():
+                target_name = alias or os.path.basename(source_ref.rstrip("/"))
+                if target_name:
+                    target_path = srcroot / target_name
+                    target_path.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(local_candidate, target_path)
+                continue
+
             source_ref = urllib.parse.urljoin(f"{base_source_prefix}", source_ref)
             parsed = urllib.parse.urlparse(source_ref)
 

--- a/tests/test_run_lpmbuild_sources.py
+++ b/tests/test_run_lpmbuild_sources.py
@@ -135,6 +135,59 @@ def test_run_lpmbuild_fetches_relative_sources(lpm_module, tmp_path, monkeypatch
         shutil.rmtree(Path(f"/tmp/{suffix}"), ignore_errors=True)
 
 
+def test_run_lpmbuild_allows_alias_for_repo_sources(lpm_module, tmp_path, monkeypatch):
+    lpm = lpm_module
+    script = tmp_path / "foo.lpmbuild"
+    script.write_text(
+        textwrap.dedent(
+            """
+            NAME=foo
+            VERSION=1
+            RELEASE=1
+            ARCH=noarch
+            SOURCE=(
+              'renamed.patch::patch.diff'
+            )
+            prepare() { :; }
+            build() { :; }
+            install() { :; }
+            """
+        )
+    )
+
+    _stub_build_pipeline(lpm, monkeypatch)
+    monkeypatch.setattr(lpm, "ok", lambda msg: None)
+    monkeypatch.setattr(lpm, "warn", lambda msg: None)
+
+    base_repo = "https://repo.example/packages"
+    monkeypatch.setitem(lpm.CONF, "LPMBUILD_REPO", base_repo)
+
+    fetched_urls: list[str] = []
+
+    def fake_urlread(url, timeout=10):
+        fetched_urls.append(url)
+        return b"payload"
+
+    monkeypatch.setattr(lpm, "urlread", fake_urlread)
+
+    out_path, _, _, _ = lpm.run_lpmbuild(
+        script,
+        outdir=tmp_path,
+        prompt_install=False,
+        build_deps=False,
+    )
+
+    assert out_path.exists()
+    srcroot = Path("/tmp/src-foo")
+    assert (srcroot / "renamed.patch").read_bytes() == b"payload"
+    expected_repo_url = f"{base_repo}/foo/patch.diff"
+    assert fetched_urls == [expected_repo_url]
+
+    out_path.unlink()
+    for suffix in ("pkg-foo", "build-foo", "src-foo"):
+        shutil.rmtree(Path(f"/tmp/{suffix}"), ignore_errors=True)
+
+
 def test_maybe_fetch_source_skips_existing_file(lpm_module, tmp_path, monkeypatch):
     lpm = lpm_module
     src_dir = tmp_path / "src"


### PR DESCRIPTION
## Summary
- update SOURCE processing so aliased entries fall back to the package repository when no local file exists
- keep support for copying local helper files while enabling remote downloads for renamed sources
- add a regression test covering aliased repository sources alongside the existing relative-source test

## Testing
- pytest tests/test_run_lpmbuild_sources.py

------
https://chatgpt.com/codex/tasks/task_e_68cff882ac548327a5856a7001ab4891