### PR TITLE
Skip metadata URL fetch when sources are present

### DIFF
--- a/lpm.py
+++ b/lpm.py
@@ -2037,15 +2037,20 @@ def run_lpmbuild(
     env["LDFLAGS"] = OPT_LEVEL
     log(f"[opt] vendor={CPU_VENDOR} family={CPU_FAMILY} -> {flags}")
 
-    # Auto-fetch source if URL provided
-    _maybe_fetch_source(url, srcroot)
+    sources = []
+    for raw_entry in arr.get("SOURCE", []):
+        entry = raw_entry.strip()
+        if entry:
+            sources.append(entry)
+
+    fetch_url_opt_in = scal.get("FETCH_URL", "").strip().lower() in {"1", "true", "yes", "on"}
+    if fetch_url_opt_in or not sources:
+        # Auto-fetch source if URL provided and explicitly requested or no SOURCE entries exist
+        _maybe_fetch_source(url, srcroot)
 
     base_repo = CONF.get("LPMBUILD_REPO", "https://gitlab.com/lpm-org/packages/-/raw/main").rstrip("/")
     base_source_prefix = f"{base_repo}/{name}/"
-    for raw_entry in arr.get("SOURCE", []):
-        entry = raw_entry.strip()
-        if not entry:
-            continue
+    for entry in sources:
         alias: Optional[str] = None
         source_ref = entry
         if "::" in entry:


### PR DESCRIPTION
## Summary
- avoid auto-fetching the metadata URL when SOURCE entries exist unless FETCH_URL is set
- reuse the normalized SOURCE list when resolving downloads
- add a regression test to ensure unreachable metadata URLs do not break builds

## Testing
- pytest tests/test_run_lpmbuild_sources.py

------
https://chatgpt.com/codex/tasks/task_e_68d0011e77c88327b131234e1517a3d8