### PR TITLE
Improve source fetch filename resolution

### DIFF
--- a/src/arch_compat.py
+++ b/src/arch_compat.py
@@ -308,7 +308,7 @@ def fetch_pkgbuild(pkgname: str, endpoints: Optional[Mapping[str, str]] = None) 
     for label, base in order:
         url = _make_pkgbuild_url(base, pkg)
         try:
-            data = urlread(url)
+            data, _ = urlread(url)
             return data.decode("utf-8")
         except Exception as exc:  # pragma: no cover - errors logged
             errors.append(f"{label}: {exc}")
@@ -337,7 +337,7 @@ def fetch_repo_index(repo: str, endpoints: Optional[Mapping[str, str]] = None) -
     for label, base in order:
         url = _make_repo_index_url(base, repo)
         try:
-            data = urlread(url)
+            data, _ = urlread(url)
             return data.decode("utf-8")
         except Exception as exc:  # pragma: no cover - errors logged
             errors.append(f"{label}: {exc}")

--- a/tests/test_run_lpmbuild_sources.py
+++ b/tests/test_run_lpmbuild_sources.py
@@ -110,7 +110,7 @@ def test_run_lpmbuild_fetches_relative_sources(lpm_module, tmp_path, monkeypatch
 
     def fake_urlread(url, timeout=10):
         fetched_urls.append(url)
-        return b"payload"
+        return b"payload", url
 
     monkeypatch.setattr(lpm, "urlread", fake_urlread)
 
@@ -168,7 +168,7 @@ def test_run_lpmbuild_downloads_multiple_url_sources(lpm_module, tmp_path, monke
 
     def fake_urlread(url, timeout=10):
         fetched_urls.append(url)
-        return f"payload:{url}".encode()
+        return f"payload:{url}".encode(), url
 
     monkeypatch.setattr(lpm, "urlread", fake_urlread)
 
@@ -228,7 +228,7 @@ def test_run_lpmbuild_allows_alias_for_repo_sources(lpm_module, tmp_path, monkey
 
     def fake_urlread(url, timeout=10):
         fetched_urls.append(url)
-        return b"payload"
+        return b"payload", url
 
     monkeypatch.setattr(lpm, "urlread", fake_urlread)
 
@@ -281,7 +281,7 @@ def test_run_lpmbuild_skips_metadata_url_fetch(lpm_module, tmp_path, monkeypatch
         if "unreachable" in url:
             raise AssertionError("metadata URL should not be fetched")
         fetched_urls.append(url)
-        return b"payload"
+        return b"payload", url
 
     monkeypatch.setattr(lpm, "urlread", fake_urlread)
 


### PR DESCRIPTION
## Summary
- update `src/fs.urlread` to return payloads alongside redirect/content-disposition filename metadata
- teach `_maybe_fetch_source` to use the metadata to choose destination names and broaden cache reuse
- adjust callers/tests and add coverage for redirected filenames

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d00f9c7d4083278fe4b6d0d3fe3e32