### PR TITLE
Ensure lpmbuild extracts primary source archive

### DIFF
--- a/tests/test_run_lpmbuild_sources.py
+++ b/tests/test_run_lpmbuild_sources.py
@@ -337,6 +337,10 @@ def test_run_lpmbuild_extracts_archive_by_default(lpm_module, tmp_path, monkeypa
     with tarfile.open(tarball, "w") as tf:
         tf.add(payload_dir, arcname="foo-1")
 
+    hook_dir = tmp_path / "hooks"
+    hook_dir.mkdir()
+    monkeypatch.setattr(lpm, "HOOK_DIR", hook_dir)
+
     script = tmp_path / "foo.lpmbuild"
     script.write_text(
         textwrap.dedent(


### PR DESCRIPTION
## Summary
- ensure run_lpmbuild's built-in extraction unpacks the primary archive into NAME-VERSION even when no hook is present
- add a Python fallback that can extract .tar.zst sources without relying on an external tar implementation
- update the lpmbuild source tests to point HOOK_DIR at an empty directory when verifying default extraction behavior

## Testing
- pytest tests/test_run_lpmbuild_sources.py

------
https://chatgpt.com/codex/tasks/task_e_68d02d1d32848327b2aa6b11e41f1282