### PR TITLE
Prompt to install split packages after base build

### DIFF
--- a/lpm.py
+++ b/lpm.py
@@ -2579,6 +2579,8 @@ def run_lpmbuild(
 
     if prompt_install:
         prompt_install_pkg(out, kind="dependency" if is_dep else "package", default=prompt_default)
+        for split_path, _split_meta in split_records:
+            prompt_install_pkg(split_path, kind="split package", default=prompt_default)
     return out, duration, phase_count, split_records
 
 # =========================== CLI commands =====================================


### PR DESCRIPTION
## Summary
- prompt the user to install split packages after the base package when builds produce them
- cover the new installation flow with a unit test that validates prompt order

## Testing
- pytest tests/test_split_packages.py

------
https://chatgpt.com/codex/tasks/task_e_68d56532e9f08327b9ecb95894838ffc