### PR TITLE
Add systemd tmpfiles hook

### DIFF
--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -110,6 +110,7 @@ def test_system_hooks_run_via_transaction_manager(tmp_path, monkeypatch, system_
         "gtk-update-icon-cache",
         "ldconfig",
         "systemd-sysusers",
+        "systemd-tmpfiles",
     ):
         p = bin_dir / name
         p.write_text(f"#!/bin/sh\necho {name} \"$@\" >> {log}\n")
@@ -128,6 +129,7 @@ def test_system_hooks_run_via_transaction_manager(tmp_path, monkeypatch, system_
             "/usr/share/icons/hicolor/index.theme",
             "/usr/lib/libfoo.so",
             "/etc/sysusers.d/foo.conf",
+            "/usr/lib/tmpfiles.d/foo.conf",
         ],
     )
     txn.ensure_pre_transaction()
@@ -140,6 +142,11 @@ def test_system_hooks_run_via_transaction_manager(tmp_path, monkeypatch, system_
     assert any("usr/share/icons/hicolor" in line for line in calls)
     assert any(
         line == f"systemd-sysusers --root {root}" for line in calls
+    )
+    assert any(
+        line
+        == "systemd-tmpfiles --create --remove --boot --root " f"{root}"
+        for line in calls
     )
     assert all(not line.startswith("ldconfig") for line in calls)
 

--- a/usr/libexec/lpm/hooks/systemd-tmpfiles
+++ b/usr/libexec/lpm/hooks/systemd-tmpfiles
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+import os
+import shutil
+import subprocess
+
+
+def main() -> None:
+    tool = shutil.which("systemd-tmpfiles")
+    if not tool:
+        return
+    root = os.environ.get("LPM_ROOT", "/")
+    subprocess.run(
+        [
+            tool,
+            "--create",
+            "--remove",
+            "--boot",
+            "--root",
+            root,
+        ],
+        check=False,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/usr/share/liblpm/hooks/systemd-tmpfiles.hook
+++ b/usr/share/liblpm/hooks/systemd-tmpfiles.hook
@@ -1,0 +1,12 @@
+[Trigger]
+Type = Path
+Operation = Install
+Operation = Upgrade
+Operation = Remove
+Target = usr/lib/tmpfiles.d/*.conf
+Target = etc/tmpfiles.d/*.conf
+
+[Action]
+When = PostTransaction
+Exec = /usr/libexec/lpm/hooks/systemd-tmpfiles
+NeedsTargets = false


### PR DESCRIPTION
## Summary
- add a systemd tmpfiles hook that watches tmpfiles.d configurations
- implement the hook runner to execute systemd-tmpfiles against the transaction root
- extend the system hook test to cover tmpfiles invocation with an alternate root

## Testing
- pytest tests/test_hooks.py::test_system_hooks_run_via_transaction_manager

------
https://chatgpt.com/codex/tasks/task_e_68d9c7deb80483278855638b09ee09f2