### PR TITLE
Add systemd daemon reload hook and tests

### DIFF
--- a/usr/libexec/lpm/hooks/systemd-daemon-reload
+++ b/usr/libexec/lpm/hooks/systemd-daemon-reload
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+import os
+import shutil
+import subprocess
+
+
+def main() -> None:
+    if os.environ.get("LPM_ROOT", "/") != "/":
+        return
+    tool = shutil.which("systemctl")
+    if not tool:
+        return
+    subprocess.run([tool, "daemon-reload"], check=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/usr/share/liblpm/hooks/systemd-daemon-reload.hook
+++ b/usr/share/liblpm/hooks/systemd-daemon-reload.hook
@@ -1,0 +1,11 @@
+[Trigger]
+Type = Path
+Operation = Install
+Operation = Upgrade
+Operation = Remove
+Target = usr/lib/systemd/system/**
+Target = etc/systemd/system/**
+
+[Action]
+When = PostTransaction
+Exec = /usr/libexec/lpm/hooks/systemd-daemon-reload


### PR DESCRIPTION
## Summary
- add a liblpm hook definition to trigger systemd daemon reloads when unit files change
- implement the systemd daemon reload hook script to only run on the real root and when systemctl is available
- add tests ensuring the daemon reload hook executes only for real-root transactions

## Testing
- pytest tests/test_hooks.py::test_systemd_daemon_reload_runs_only_for_real_root

------
https://chatgpt.com/codex/tasks/task_e_68d9c896953083278237ddafa3948e34