### PR TITLE
Add MIME database update hook

### DIFF
--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -101,6 +101,8 @@ def test_system_hooks_run_via_transaction_manager(tmp_path, monkeypatch, system_
     (root / "usr/share/icons/hicolor/index.theme").write_text("[Icon Theme]")
     (root / "usr/share/applications").mkdir(parents=True)
     (root / "usr/share/applications/foo.desktop").write_text("[Desktop Entry]")
+    (root / "usr/share/mime/packages").mkdir(parents=True)
+    (root / "usr/share/mime/packages/foo.xml").write_text("<mime-info>")
 
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -108,6 +110,7 @@ def test_system_hooks_run_via_transaction_manager(tmp_path, monkeypatch, system_
     for name in (
         "update-desktop-database",
         "gtk-update-icon-cache",
+        "update-mime-database",
         "ldconfig",
         "systemd-sysusers",
         "systemd-tmpfiles",
@@ -131,6 +134,7 @@ def test_system_hooks_run_via_transaction_manager(tmp_path, monkeypatch, system_
         paths=[
             "/usr/share/applications/foo.desktop",
             "/usr/share/icons/hicolor/index.theme",
+            "/usr/share/mime/packages/foo.xml",
             "/usr/lib/libfoo.so",
             "/etc/sysusers.d/foo.conf",
             "/usr/lib/tmpfiles.d/foo.conf",
@@ -145,6 +149,8 @@ def test_system_hooks_run_via_transaction_manager(tmp_path, monkeypatch, system_
     assert any("usr/share/applications" in line for line in calls)
     assert any(line.startswith("gtk-update-icon-cache") for line in calls)
     assert any("usr/share/icons/hicolor" in line for line in calls)
+    assert any(line.startswith("update-mime-database") for line in calls)
+    assert any(str(root / "usr/share/mime") in line for line in calls)
     assert any(
         line == f"systemd-sysusers --root {root}" for line in calls
     )

--- a/usr/libexec/lpm/hooks/update-mime-database
+++ b/usr/libexec/lpm/hooks/update-mime-database
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List, Set
+
+
+def _iter_mime_dirs(root: Path, targets: Iterable[str]) -> List[Path]:
+    seen: Set[Path] = set()
+    dirs: List[Path] = []
+    for target in targets:
+        rel = str(target).lstrip("/")
+        if not rel:
+            continue
+        path = Path(rel)
+        if path.suffix.lower() != ".xml":
+            continue
+        packages_dir = path.parent
+        while packages_dir != packages_dir.parent and packages_dir.name != "packages":
+            packages_dir = packages_dir.parent
+        if packages_dir.name != "packages":
+            continue
+        candidate = root / packages_dir.parent
+        if candidate in seen or not candidate.is_dir():
+            continue
+        seen.add(candidate)
+        dirs.append(candidate)
+    if dirs:
+        return dirs
+    default = root / "usr/share/mime"
+    if default.is_dir():
+        dirs.append(default)
+    return dirs
+
+
+def main(argv: List[str]) -> None:
+    tool = shutil.which("update-mime-database")
+    if not tool:
+        return
+    root = Path(os.environ.get("LPM_ROOT", "/"))
+    targets = _iter_mime_dirs(root, argv)
+    for directory in targets:
+        subprocess.run([tool, str(directory)], check=False)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/usr/share/liblpm/hooks/update-mime-database.hook
+++ b/usr/share/liblpm/hooks/update-mime-database.hook
@@ -1,0 +1,11 @@
+[Trigger]
+Type = Path
+Operation = Install
+Operation = Upgrade
+Operation = Remove
+Target = usr/share/mime/packages/*.xml
+
+[Action]
+When = PostTransaction
+Exec = /usr/libexec/lpm/hooks/update-mime-database
+NeedsTargets = true


### PR DESCRIPTION
## Summary
- add a system hook to watch MIME package XML updates
- implement the update-mime-database helper to deduplicate targets and run the tool
- extend the system hook test to cover invoking update-mime-database

## Testing
- pytest tests/test_hooks.py

------
https://chatgpt.com/codex/tasks/task_e_68d9ca3c07908327b29970be40f74fed