### PR TITLE
Add glib schema compilation hook

### DIFF
--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -103,6 +103,10 @@ def test_system_hooks_run_via_transaction_manager(tmp_path, monkeypatch, system_
     (root / "usr/share/applications/foo.desktop").write_text("[Desktop Entry]")
     (root / "usr/share/mime/packages").mkdir(parents=True)
     (root / "usr/share/mime/packages/foo.xml").write_text("<mime-info>")
+    (root / "usr/share/glib-2.0/schemas").mkdir(parents=True)
+    (root / "usr/share/glib-2.0/schemas/org.example.gschema.xml").write_text(
+        "<schemalist>"
+    )
 
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -112,6 +116,7 @@ def test_system_hooks_run_via_transaction_manager(tmp_path, monkeypatch, system_
         "gtk-update-icon-cache",
         "update-mime-database",
         "ldconfig",
+        "glib-compile-schemas",
         "systemd-sysusers",
         "systemd-tmpfiles",
         "udevadm",
@@ -135,6 +140,7 @@ def test_system_hooks_run_via_transaction_manager(tmp_path, monkeypatch, system_
             "/usr/share/applications/foo.desktop",
             "/usr/share/icons/hicolor/index.theme",
             "/usr/share/mime/packages/foo.xml",
+            "/usr/share/glib-2.0/schemas/org.example.gschema.xml",
             "/usr/lib/libfoo.so",
             "/etc/sysusers.d/foo.conf",
             "/usr/lib/tmpfiles.d/foo.conf",
@@ -151,6 +157,8 @@ def test_system_hooks_run_via_transaction_manager(tmp_path, monkeypatch, system_
     assert any("usr/share/icons/hicolor" in line for line in calls)
     assert any(line.startswith("update-mime-database") for line in calls)
     assert any(str(root / "usr/share/mime") in line for line in calls)
+    assert any(line.startswith("glib-compile-schemas") for line in calls)
+    assert any("--targetdir=" in line for line in calls)
     assert any(
         line == f"systemd-sysusers --root {root}" for line in calls
     )

--- a/usr/libexec/lpm/hooks/glib-compile-schemas
+++ b/usr/libexec/lpm/hooks/glib-compile-schemas
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List, Set
+
+
+def _iter_schema_dirs(root: Path, targets: Iterable[str]) -> List[Path]:
+    seen: Set[Path] = set()
+    directories: List[Path] = []
+    for target in targets:
+        rel = str(target).lstrip("/")
+        if not rel:
+            continue
+        path = root / rel
+        if path.suffix.lower() != ".xml":
+            continue
+        parent = path.parent
+        if parent in seen or not parent.is_dir():
+            continue
+        seen.add(parent)
+        directories.append(parent)
+    return directories
+
+
+def main(argv: List[str]) -> None:
+    tool = shutil.which("glib-compile-schemas")
+    if not tool:
+        return
+    root = Path(os.environ.get("LPM_ROOT", "/"))
+    for directory in _iter_schema_dirs(root, argv):
+        subprocess.run(
+            [tool, f"--targetdir={directory}", str(directory)],
+            check=False,
+        )
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/usr/share/liblpm/hooks/glib-compile-schemas.hook
+++ b/usr/share/liblpm/hooks/glib-compile-schemas.hook
@@ -1,0 +1,11 @@
+[Trigger]
+Type = Path
+Operation = Install
+Operation = Upgrade
+Operation = Remove
+Target = usr/share/glib-2.0/schemas/*.xml
+
+[Action]
+When = PostTransaction
+Exec = /usr/libexec/lpm/hooks/glib-compile-schemas
+NeedsTargets = true


### PR DESCRIPTION
## Summary
- add a liblpm hook that triggers on GLib schema XML updates
- implement the hook helper to run glib-compile-schemas for affected directories
- cover the new hook in the system hooks test suite

## Testing
- pytest tests/test_hooks.py


------
https://chatgpt.com/codex/tasks/task_e_68d9cb5d354c8327a89c68815befdb4b