### PR TITLE
Add gio-querymodules hook support

### DIFF
--- a/usr/libexec/lpm/hooks/gio-querymodules
+++ b/usr/libexec/lpm/hooks/gio-querymodules
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List, Set, Tuple
+
+
+def _iter_module_dirs(root: Path, targets: Iterable[str]) -> List[Tuple[Path, Path]]:
+    seen: Set[Path] = set()
+    result: List[Tuple[Path, Path]] = []
+    for target in targets:
+        if not target:
+            continue
+        rel_text = target.lstrip("/")
+        if not rel_text:
+            continue
+        rel_path = Path(rel_text)
+        if rel_path.suffix != ".so":
+            continue
+        rel_dir = rel_path.parent
+        if not rel_dir.parts:
+            continue
+        if rel_dir not in seen:
+            seen.add(rel_dir)
+        else:
+            continue
+        module_dir = root / rel_dir
+        if module_dir.is_dir():
+            result.append((module_dir, rel_dir))
+    return result
+
+
+def main(argv: List[str]) -> None:
+    tool = shutil.which("gio-querymodules")
+    if not tool:
+        return
+    root = Path(os.environ.get("LPM_ROOT", "/"))
+    modules = _iter_module_dirs(root, argv)
+    for module_dir, rel_dir in modules:
+        output = root / rel_dir / "giomodule.cache"
+        subprocess.run(
+            [tool, "--output", str(output), str(module_dir)],
+            check=False,
+        )
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/usr/share/liblpm/hooks/gio-querymodules.hook
+++ b/usr/share/liblpm/hooks/gio-querymodules.hook
@@ -1,0 +1,11 @@
+[Trigger]
+Type = Path
+Operation = Install
+Operation = Upgrade
+Operation = Remove
+Target = usr/lib/gio/modules/*.so
+
+[Action]
+When = PostTransaction
+Exec = /usr/libexec/lpm/hooks/gio-querymodules
+NeedsTargets = true


### PR DESCRIPTION
## Summary
- add a gio-querymodules hook that watches GIO module shared objects and runs the helper script after transactions
- implement the gio-querymodules helper to deduplicate module directories relative to LPM_ROOT and write caches under the correct root
- extend the system hook test to cover the gio-querymodules invocation

## Testing
- pytest tests/test_hooks.py

------
https://chatgpt.com/codex/tasks/task_e_68d9d5e540bc8327a1bc5bba13ab94f2