### PR TITLE
Add gdk-pixbuf loader cache hook

### DIFF
--- a/usr/libexec/lpm/hooks/gdk-pixbuf-query-loaders
+++ b/usr/libexec/lpm/hooks/gdk-pixbuf-query-loaders
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List, Set, Tuple
+
+
+def _iter_loader_dirs(root: Path, targets: Iterable[str]) -> List[Tuple[Path, Path]]:
+    seen: Set[Path] = set()
+    result: List[Tuple[Path, Path]] = []
+    for target in targets:
+        if not target:
+            continue
+        rel_text = target.lstrip("/")
+        if not rel_text:
+            continue
+        rel_path = Path(rel_text)
+        if rel_path.suffix != ".so":
+            continue
+        rel_dir = rel_path.parent
+        if rel_dir.name != "loaders":
+            continue
+        module_dir = root / rel_dir
+        if module_dir in seen:
+            continue
+        if not module_dir.is_dir():
+            continue
+        seen.add(module_dir)
+        module_file = module_dir.parent / "loaders.cache"
+        result.append((module_dir, module_file))
+    return result
+
+
+def main(argv: List[str]) -> None:
+    tool = shutil.which("gdk-pixbuf-query-loaders")
+    if not tool:
+        return
+    root = Path(os.environ.get("LPM_ROOT", "/"))
+    for module_dir, module_file in _iter_loader_dirs(root, argv):
+        env = os.environ.copy()
+        env.update(
+            {
+                "GDK_PIXBUF_MODULEDIR": str(module_dir),
+                "GDK_PIXBUF_MODULE_FILE": str(module_file),
+            }
+        )
+        subprocess.run([tool, "--update-cache"], check=False, env=env)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/usr/share/liblpm/hooks/gdk-pixbuf-query-loaders.hook
+++ b/usr/share/liblpm/hooks/gdk-pixbuf-query-loaders.hook
@@ -1,0 +1,11 @@
+[Trigger]
+Type = Path
+Operation = Install
+Operation = Upgrade
+Operation = Remove
+Target = usr/lib/gdk-pixbuf-2.0/*/loaders/*.so
+
+[Action]
+When = PostTransaction
+Exec = /usr/libexec/lpm/hooks/gdk-pixbuf-query-loaders
+NeedsTargets = true


### PR DESCRIPTION
## Summary
- add a gdk-pixbuf system hook that reacts to loader shared objects
- implement the hook helper to set module cache environment variables and call gdk-pixbuf-query-loaders
- expand the system hook test to cover the gdk-pixbuf invocation and environment

## Testing
- pytest tests/test_hooks.py -k system_hooks_run_via_transaction_manager


------
https://chatgpt.com/codex/tasks/task_e_68d9d717a4c88327a580e174848d3b45