### PR TITLE
Compile Python hook scripts during build

### DIFF
--- a/tools/list_python_hooks.py
+++ b/tools/list_python_hooks.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Enumerate Python-based hook scripts for Nuitka compilation."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+
+def _iter_python_hook_scripts(base: Path) -> Iterable[Path]:
+    for path in sorted(base.rglob("*")):
+        if not path.is_file():
+            continue
+        if path.suffix == ".py":
+            yield path
+            continue
+        try:
+            with path.open("rb") as handle:
+                first_line = handle.readline()
+        except OSError:
+            continue
+        if first_line.startswith(b"#!") and b"python" in first_line.lower():
+            yield path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "root",
+        nargs="?",
+        default="usr/share/lpm/hooks",
+        help="Root directory to scan for hook scripts",
+    )
+    args = parser.parse_args()
+    base = Path(args.root)
+    if not base.is_dir():
+        return
+
+    for path in _iter_python_hook_scripts(base):
+        print(path)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()


### PR DESCRIPTION
## Summary
- build python-based hook scripts with Nuitka alongside the main binary and stage the compiled results
- add a helper utility for the Makefile to discover hook scripts to compile
- allow the hook runner to execute precompiled hook binaries directly

## Testing
- not run (QA review only)


------
https://chatgpt.com/codex/tasks/task_e_68d9d9386ab0832789f469f6e4a84ae0