### PR TITLE
Build liblpm hooks during packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,40 +14,59 @@ HOOK_BUILD_DIR = $(BUILD_DIR)/hooks
 STAGING_DIR = $(DIST_DIR)/$(APP)-$(VERSION)
 TARBALL = $(DIST_DIR)/$(APP)-$(VERSION).tar.gz
 HOOK_SRC = usr/share/lpm/hooks
+LIBLPM_HOOK_SRC = usr/libexec/lpm/hooks
+LIBLPM_HOOK_BUILD_DIR = $(BUILD_DIR)/libexec_hooks
 
 HOOK_PYTHON_SCRIPTS := $(shell $(PYTHON) tools/list_python_hooks.py $(HOOK_SRC))
 HOOK_BINARIES := $(patsubst $(HOOK_SRC)/%, $(HOOK_BUILD_DIR)/%, $(HOOK_PYTHON_SCRIPTS))
+LIBLPM_HOOK_PYTHON_SCRIPTS := $(shell $(PYTHON) tools/list_python_hooks.py $(LIBLPM_HOOK_SRC))
+LIBLPM_HOOK_BINARIES := $(patsubst $(LIBLPM_HOOK_SRC)/%, $(LIBLPM_HOOK_BUILD_DIR)/%, $(LIBLPM_HOOK_PYTHON_SCRIPTS))
 
 .PHONY: all stage tarball clean distclean
 .ONESHELL:
 
-all: $(BIN_TARGET) $(HOOK_BINARIES)
+all: $(BIN_TARGET) $(HOOK_BINARIES) $(LIBLPM_HOOK_BINARIES)
 
 $(BIN_TARGET): lpm.py $(SRC_FILES)
 	@mkdir -p $(BUILD_DIR)
 	$(NUITKA) --onefile --include-package=src --follow-imports --output-dir=$(BUILD_DIR) --output-filename=$(APP).bin $(ENTRY)
 
 $(HOOK_BUILD_DIR)/%: $(HOOK_SRC)/%
-	@mkdir -p $(dir $@)
-	$(NUITKA) --onefile --include-package=src --follow-imports --output-dir=$(dir $@) --output-filename=$(notdir $@) $<
+        @mkdir -p $(dir $@)
+        $(NUITKA) --onefile --include-package=src --follow-imports --output-dir=$(dir $@) --output-filename=$(notdir $@) $<
 
-$(STAGING_DIR): $(BIN_TARGET) README.md LICENSE etc/lpm/lpm.conf $(HOOK_BINARIES)
-	@mkdir -p $(DIST_DIR)
-	@rm -rf $@
-	mkdir -p $@/bin
-	cp $(BIN_TARGET) $@/bin/$(APP)
-	mkdir -p $@/usr/share/lpm
-	cp -R $(HOOK_SRC) $@/usr/share/lpm/
-	if [ -n "$(HOOK_BINARIES)" ]; then \
-	    for hook in $(HOOK_BINARIES); do \
-	        rel=$${hook#$(HOOK_BUILD_DIR)/}; \
-	        dest="$@/usr/share/lpm/hooks/$${rel}"; \
-	        install -D -m 0755 "$$hook" "$$dest"; \
-	    done; \
-	fi
-	mkdir -p $@/etc/lpm
-	cp etc/lpm/lpm.conf $@/etc/lpm/lpm.conf
-	cp README.md LICENSE $@
+$(LIBLPM_HOOK_BUILD_DIR)/%: $(LIBLPM_HOOK_SRC)/%
+        @mkdir -p $(dir $@)
+        $(NUITKA) --onefile --include-package=src --follow-imports --output-dir=$(dir $@) --output-filename=$(notdir $@) $<
+
+$(STAGING_DIR): $(BIN_TARGET) README.md LICENSE etc/lpm/lpm.conf $(HOOK_BINARIES) $(LIBLPM_HOOK_BINARIES)
+        @mkdir -p $(DIST_DIR)
+        @rm -rf $@
+        mkdir -p $@/bin
+        cp $(BIN_TARGET) $@/bin/$(APP)
+        mkdir -p $@/usr/share/lpm
+        cp -R $(HOOK_SRC) $@/usr/share/lpm/
+        if [ -n "$(HOOK_BINARIES)" ]; then \
+            for hook in $(HOOK_BINARIES); do \
+                rel=$${hook#$(HOOK_BUILD_DIR)/}; \
+                dest="$@/usr/share/lpm/hooks/$${rel}"; \
+                install -D -m 0755 "$$hook" "$$dest"; \
+            done; \
+        fi
+        mkdir -p $@/usr/share/liblpm
+        cp -R usr/share/liblpm/hooks $@/usr/share/liblpm/
+        mkdir -p $@/usr/libexec/lpm
+        cp -R $(LIBLPM_HOOK_SRC) $@/usr/libexec/lpm/
+        if [ -n "$(LIBLPM_HOOK_BINARIES)" ]; then \
+            for hook in $(LIBLPM_HOOK_BINARIES); do \
+                rel=$${hook#$(LIBLPM_HOOK_BUILD_DIR)/}; \
+                dest="$@/usr/libexec/lpm/hooks/$${rel}"; \
+                install -D -m 0755 "$$hook" "$$dest"; \
+            done; \
+        fi
+        mkdir -p $@/etc/lpm
+        cp etc/lpm/lpm.conf $@/etc/lpm/lpm.conf
+        cp README.md LICENSE $@
 	cat <<-'INSTALL_SH' > $@/install.sh
 	#!/bin/sh
 	set -eu
@@ -58,10 +77,20 @@ $(STAGING_DIR): $(BIN_TARGET) README.md LICENSE etc/lpm/lpm.conf $(HOOK_BINARIES
 	mkdir -p "$${DESTDIR}$${PREFIX}/bin"
 	install -m 0755 "$${ROOT}/bin/lpm" "$${DESTDIR}$${PREFIX}/bin/lpm"
 	
-	HOOK_DEST="$${DESTDIR}/usr/share/lpm"
-	rm -rf "$${HOOK_DEST}/hooks"
-	mkdir -p "$${HOOK_DEST}"
-	cp -R "$${ROOT}/usr/share/lpm/hooks" "$${HOOK_DEST}/"
+        HOOK_DEST="$${DESTDIR}/usr/share/lpm"
+        rm -rf "$${HOOK_DEST}/hooks"
+        mkdir -p "$${HOOK_DEST}"
+        cp -R "$${ROOT}/usr/share/lpm/hooks" "$${HOOK_DEST}/"
+
+        LIBLPM_HOOK_DEST="$${DESTDIR}/usr/share/liblpm"
+        rm -rf "$${LIBLPM_HOOK_DEST}/hooks"
+        mkdir -p "$${LIBLPM_HOOK_DEST}"
+        cp -R "$${ROOT}/usr/share/liblpm/hooks" "$${LIBLPM_HOOK_DEST}/"
+
+        EXEC_HOOK_DEST="$${DESTDIR}/usr/libexec/lpm"
+        rm -rf "$${EXEC_HOOK_DEST}/hooks"
+        mkdir -p "$${EXEC_HOOK_DEST}"
+        cp -R "$${ROOT}/usr/libexec/lpm/hooks" "$${EXEC_HOOK_DEST}/"
 	
 	STATE_DIR="$${DESTDIR}/var/lib/lpm"
 	mkdir -p "$${STATE_DIR}/cache" "$${STATE_DIR}/snapshots"


### PR DESCRIPTION
## Summary
- compile the liblpm hook helpers with Nuitka alongside the existing LPM hook build
- stage the liblpm hook definitions and binaries so they ship in the archive
- update the generated install.sh to install both the LPM and liblpm hook trees

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9e060caa08327b32941c640b21e47