### PR TITLE
Fix Makefile indentation to restore valid recipes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,41 +32,41 @@ $(BIN_TARGET): lpm.py $(SRC_FILES)
 	$(NUITKA) --onefile --include-package=src --follow-imports --output-dir=$(BUILD_DIR) --output-filename=$(APP).bin $(ENTRY)
 
 $(HOOK_BUILD_DIR)/%: $(HOOK_SRC)/%
-        @mkdir -p $(dir $@)
-        $(NUITKA) --onefile --include-package=src --follow-imports --output-dir=$(dir $@) --output-filename=$(notdir $@) $<
+	@mkdir -p $(dir $@)
+	$(NUITKA) --onefile --include-package=src --follow-imports --output-dir=$(dir $@) --output-filename=$(notdir $@) $<
 
 $(LIBLPM_HOOK_BUILD_DIR)/%: $(LIBLPM_HOOK_SRC)/%
-        @mkdir -p $(dir $@)
-        $(NUITKA) --onefile --include-package=src --follow-imports --output-dir=$(dir $@) --output-filename=$(notdir $@) $<
+	@mkdir -p $(dir $@)
+	$(NUITKA) --onefile --include-package=src --follow-imports --output-dir=$(dir $@) --output-filename=$(notdir $@) $<
 
 $(STAGING_DIR): $(BIN_TARGET) README.md LICENSE etc/lpm/lpm.conf $(HOOK_BINARIES) $(LIBLPM_HOOK_BINARIES)
-        @mkdir -p $(DIST_DIR)
-        @rm -rf $@
-        mkdir -p $@/bin
-        cp $(BIN_TARGET) $@/bin/$(APP)
-        mkdir -p $@/usr/share/lpm
-        cp -R $(HOOK_SRC) $@/usr/share/lpm/
-        if [ -n "$(HOOK_BINARIES)" ]; then \
-            for hook in $(HOOK_BINARIES); do \
-                rel=$${hook#$(HOOK_BUILD_DIR)/}; \
-                dest="$@/usr/share/lpm/hooks/$${rel}"; \
-                install -D -m 0755 "$$hook" "$$dest"; \
-            done; \
-        fi
-        mkdir -p $@/usr/share/liblpm
-        cp -R usr/share/liblpm/hooks $@/usr/share/liblpm/
-        mkdir -p $@/usr/libexec/lpm
-        cp -R $(LIBLPM_HOOK_SRC) $@/usr/libexec/lpm/
-        if [ -n "$(LIBLPM_HOOK_BINARIES)" ]; then \
-            for hook in $(LIBLPM_HOOK_BINARIES); do \
-                rel=$${hook#$(LIBLPM_HOOK_BUILD_DIR)/}; \
-                dest="$@/usr/libexec/lpm/hooks/$${rel}"; \
-                install -D -m 0755 "$$hook" "$$dest"; \
-            done; \
-        fi
-        mkdir -p $@/etc/lpm
-        cp etc/lpm/lpm.conf $@/etc/lpm/lpm.conf
-        cp README.md LICENSE $@
+	@mkdir -p $(DIST_DIR)
+	@rm -rf $@
+	mkdir -p $@/bin
+	cp $(BIN_TARGET) $@/bin/$(APP)
+	mkdir -p $@/usr/share/lpm
+	cp -R $(HOOK_SRC) $@/usr/share/lpm/
+	if [ -n "$(HOOK_BINARIES)" ]; then \
+		for hook in $(HOOK_BINARIES); do \
+		rel=$${hook#$(HOOK_BUILD_DIR)/}; \
+		dest="$@/usr/share/lpm/hooks/$${rel}"; \
+		install -D -m 0755 "$$hook" "$$dest"; \
+		done; \
+	fi
+	mkdir -p $@/usr/share/liblpm
+	cp -R usr/share/liblpm/hooks $@/usr/share/liblpm/
+	mkdir -p $@/usr/libexec/lpm
+	cp -R $(LIBLPM_HOOK_SRC) $@/usr/libexec/lpm/
+	if [ -n "$(LIBLPM_HOOK_BINARIES)" ]; then \
+		for hook in $(LIBLPM_HOOK_BINARIES); do \
+		rel=$${hook#$(LIBLPM_HOOK_BUILD_DIR)/}; \
+		dest="$@/usr/libexec/lpm/hooks/$${rel}"; \
+		install -D -m 0755 "$$hook" "$$dest"; \
+		done; \
+	fi
+	mkdir -p $@/etc/lpm
+	cp etc/lpm/lpm.conf $@/etc/lpm/lpm.conf
+	cp README.md LICENSE $@
 	cat <<-'INSTALL_SH' > $@/install.sh
 	#!/bin/sh
 	set -eu


### PR DESCRIPTION
## Summary
- replace space-indented Makefile recipe lines with tab-indented ones so make recognizes the commands
- keep nested loop commands indented for readability while preserving required separators

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9e3bb93a88327ba50add874385d81