### PR TITLE
Initialize install hook transaction defaults

### DIFF
--- a/lpm.py
+++ b/lpm.py
@@ -3535,6 +3535,16 @@ def installpkg(
     global PROTECTED
     PROTECTED = load_protected()
 
+    txn = hook_transaction
+    owns_txn = False
+    if txn is None and not dry_run:
+        txn = HookTransactionManager(
+            hooks=load_hooks(LIBLPM_HOOK_DIRS),
+            root=root,
+            base_env={"LPM_ROOT": str(root)},
+        )
+        owns_txn = True
+
     # --- Step 1: Validate extension + magic ---
     if file.suffix != EXT:
         die(f"{file.name} is not a {EXT} package")


### PR DESCRIPTION
## Summary
- ensure `installpkg` initializes its hook transaction locals so they are always defined
- create a `HookTransactionManager` during installs when no transaction is provided and hooks are needed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da9c29c29083278e16ab6c80db4ab3