### PR TITLE
Add pip dependency support to .lpmbuild builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ contents and runs common maintenance commands based on what it finds:
   `{LPMBUILD_REPO}/{pkgname}/{filename}`, matching Arch Linux's `source=()`
   behaviour, while explicit URLs and `foo::https://example.com/src` rename
   syntax are honoured as-is.【F:lpm.py†L2116-L2159】
+  For Python dependencies that should be sourced from PyPI, add a
+  `REQUIRES_PYTHON_DEPENDENCIES=()` array with standard pip requirement
+  strings such as `('requests==2.0')`; `lpm buildpkg` canonicalises the
+  distribution names, skips entries already provided by packages exposing
+  `pypi(<name>)`, and otherwise invokes the built-in pip builder (with
+  dependency resolution enabled) before executing your script.【F:lpm.py†L2367-L2486】
 - `lpm genindex REPO_DIR [--base-url URL] [--arch ARCH]` – generate an
   `index.json` for a directory of packages.
 - `lpm installpkg FILE... [--root PATH] [--dry-run] [--verify] [--force]`

--- a/tests/test_run_lpmbuild_dependencies.py
+++ b/tests/test_run_lpmbuild_dependencies.py
@@ -55,7 +55,10 @@ for name in ("zstandard", "tqdm"):
 import lpm
 
 
-def _write_dummy_lpmbuild(script: Path, deps):
+def _write_dummy_lpmbuild(script: Path, deps, python_deps=None):
+    python_block = ""
+    if python_deps:
+        python_block = f"REQUIRES_PYTHON_DEPENDENCIES=({' '.join(python_deps)})\n"
     script.write_text(
         textwrap.dedent(
             """
@@ -64,11 +67,11 @@ def _write_dummy_lpmbuild(script: Path, deps):
             RELEASE=1
             ARCH=noarch
             REQUIRES=({deps})
-            prepare() {{ :; }}
+            {python_block}prepare() {{ :; }}
             build() {{ :; }}
             staging() {{ :; }}
             """
-        ).format(deps=" ".join(deps))
+        ).format(deps=" ".join(deps), python_block=python_block)
     )
 
 
@@ -80,6 +83,91 @@ def _stub_build_pipeline(monkeypatch):
         out.write_text("pkg")
 
     monkeypatch.setattr(lpm, "build_package", fake_build_package)
+
+
+def test_run_lpmbuild_builds_python_dependencies_when_missing(tmp_path, monkeypatch):
+    script = tmp_path / "foo.lpmbuild"
+    _write_dummy_lpmbuild(script, [], python_deps=["requests==2.0"])
+
+    monkeypatch.setenv("LPM_STATE_DIR", str(tmp_path / "state"))
+    _stub_build_pipeline(monkeypatch)
+
+    class DummyConn:
+        def close(self):
+            return None
+
+    monkeypatch.setattr(lpm, "db", lambda: DummyConn())
+    monkeypatch.setattr(lpm, "db_installed", lambda conn: {})
+
+    calls = []
+
+    def fake_build_python_package_from_pip(spec, outdir, include_deps):
+        calls.append((spec, Path(outdir), include_deps))
+        out_path = Path(outdir) / "python-requests-2.0-1.noarch.zst"
+        out_path.write_text("pkg")
+        meta = lpm.PkgMeta(
+            name="python-requests",
+            version="2.0",
+            release="1",
+            arch="noarch",
+            provides=["pypi(requests)"],
+        )
+        return out_path, meta, 0.1
+
+    monkeypatch.setattr(lpm, "build_python_package_from_pip", fake_build_python_package_from_pip)
+
+    out_path, _, _, _ = lpm.run_lpmbuild(
+        script,
+        outdir=tmp_path,
+        prompt_install=False,
+        build_deps=True,
+    )
+
+    assert calls == [("requests==2.0", tmp_path, True)]
+    assert out_path.exists()
+
+    out_path.unlink()
+    shutil.rmtree(Path("/tmp/pkg-foo"), ignore_errors=True)
+    shutil.rmtree(Path("/tmp/build-foo"), ignore_errors=True)
+    shutil.rmtree(Path("/tmp/src-foo"), ignore_errors=True)
+
+
+def test_run_lpmbuild_skips_python_dependencies_when_provided(tmp_path, monkeypatch):
+    script = tmp_path / "foo.lpmbuild"
+    _write_dummy_lpmbuild(script, [], python_deps=["requests==2.0"])
+
+    monkeypatch.setenv("LPM_STATE_DIR", str(tmp_path / "state"))
+    _stub_build_pipeline(monkeypatch)
+
+    class DummyConn:
+        def close(self):
+            return None
+
+    monkeypatch.setattr(lpm, "db", lambda: DummyConn())
+    monkeypatch.setattr(
+        lpm,
+        "db_installed",
+        lambda conn: {"python-requests": {"provides": ["pypi(requests)"]}},
+    )
+
+    def fake_build_python_package_from_pip(*args, **kwargs):
+        raise AssertionError("unexpected Python dependency build")
+
+    monkeypatch.setattr(lpm, "build_python_package_from_pip", fake_build_python_package_from_pip)
+
+    out_path, _, _, _ = lpm.run_lpmbuild(
+        script,
+        outdir=tmp_path,
+        prompt_install=False,
+        build_deps=True,
+    )
+
+    assert out_path.exists()
+
+    out_path.unlink()
+    shutil.rmtree(Path("/tmp/pkg-foo"), ignore_errors=True)
+    shutil.rmtree(Path("/tmp/build-foo"), ignore_errors=True)
+    shutil.rmtree(Path("/tmp/src-foo"), ignore_errors=True)
 
 
 def test_run_lpmbuild_skips_dependencies_satisfied_by_provides(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- capture REQUIRES_PYTHON_DEPENDENCIES from .lpmbuild metadata
- build missing pip requirements during run_lpmbuild while caching pypi() provides
- document the new array and cover it with targeted tests

## Testing
- pytest tests/test_run_lpmbuild_dependencies.py

------
https://chatgpt.com/codex/tasks/task_e_68dff78512bc8327bb9a75d85fd53cce