### PR TITLE
Short-circuit python dependency builds when already installed

### DIFF
--- a/lpm.py
+++ b/lpm.py
@@ -2572,6 +2572,8 @@ def run_lpmbuild(
                 trimmed_name = canonical_name[len("python-") :]
                 if trimmed_name:
                     capability_names.add(trimmed_name)
+            if any(name in capabilities for name in capability_names):
+                continue
             if any(f"pypi({name})" in capabilities for name in capability_names):
                 continue
             key = ("python", canonical_name)


### PR DESCRIPTION
## Summary
- short-circuit python dependency builds in `run_lpmbuild` when an installed capability matches the requirement name or its trimmed alias
- add a regression test ensuring installed Python packages without `pypi(...)` provides are not rebuilt

## Testing
- pytest tests/test_run_lpmbuild_dependencies.py

------
https://chatgpt.com/codex/tasks/task_e_68e00f69484483279ece6cd019f43b10