### PR TITLE
Add zstandard version shim for Nuitka compatibility

### DIFF
--- a/zstandard.py
+++ b/zstandard.py
@@ -1,5 +1,10 @@
 """Minimal :mod:`zstandard` compatibility layer for the test environment."""
 
+# ``nuitka`` queries :mod:`zstandard` for a ``__version__`` attribute when it is
+# installed.  The real third-party package exposes this constant, so we provide
+# a placeholder value to keep tools that import the shim behaving as expected.
+__version__ = "0.0"
+
 from __future__ import annotations
 
 from typing import BinaryIO, Optional


### PR DESCRIPTION
## Summary
- add a placeholder __version__ attribute to the zstandard compatibility shim so tools depending on it continue to work

## Testing
- make all (fails: /root/.pyenv/versions/3.11.12/bin/python3: No module named nuitka)


------
https://chatgpt.com/codex/tasks/task_e_68e3e06fe0448327855df54b73ee2661