### PR TITLE
Fix zstandard shim future import placement

### DIFF
--- a/zstandard.py
+++ b/zstandard.py
@@ -1,13 +1,13 @@
 """Minimal :mod:`zstandard` compatibility layer for the test environment."""
 
+from __future__ import annotations
+
+from typing import BinaryIO, Optional
+
 # ``nuitka`` queries :mod:`zstandard` for a ``__version__`` attribute when it is
 # installed.  The real third-party package exposes this constant, so we provide
 # a placeholder value to keep tools that import the shim behaving as expected.
 __version__ = "0.0"
-
-from __future__ import annotations
-
-from typing import BinaryIO, Optional
 
 _MAGIC = b"\x28\xB5\x2F\xFD"
 


### PR DESCRIPTION
## Summary
- move the `from __future__ import annotations` statement ahead of other module-level code in the zstandard compatibility shim so Nuitka can compile it

## Testing
- make build/nuitka/lpm.bin *(fails: No module named nuitka)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e2761f5c8327ac4765b39c98cabd