### PR TITLE
Handle zstd shim fallback when decompressing packages

### DIFF
--- a/zstandard.py
+++ b/zstandard.py
@@ -66,6 +66,13 @@ class _Reader:
                 break
             yield chunk
 
+    def __enter__(self) -> "_Reader":  # pragma: no cover - compatibility shim
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - compatibility shim
+        self.close()
+        return None
+
 
 class ZstdCompressor:
     def stream_writer(self, fh: BinaryIO) -> _Writer:


### PR DESCRIPTION
## Summary
- add a streaming helper that shells out to `zstd -dc` when the Python shim cannot decode a package
- wrap zstandard stream readers so underlying file handles are closed and retry with the CLI when needed
- teach the bundled shim to support context manager usage for compatibility

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e532e7585c8327a7ac84fb254e6785