### PR TITLE
Trigger kernel-install hook for module updates

### DIFF
--- a/usr/share/liblpm/hooks/kernel-install.hook
+++ b/usr/share/liblpm/hooks/kernel-install.hook
@@ -4,6 +4,8 @@ Operation = Install
 Operation = Upgrade
 Target = usr/lib/modules/*/vmlinuz
 Target = usr/lib/modules/*/pkgbase
+Target = usr/lib/modules/*/modules.*
+Target = usr/lib/modules/*/kernel/*
 
 [Action]
 When = PostTransaction


### PR DESCRIPTION
## Summary
- broaden the kernel-install transaction hook to fire when module files are installed or upgraded
- add a regression test ensuring module-only kernel packages rebuild initrds and refresh bootloaders

## Testing
- pytest tests/test_hooks.py::test_kernel_install_transaction_hook tests/test_hooks.py::test_kernel_modules_install_transaction_hook -q

------
https://chatgpt.com/codex/tasks/task_e_68e5c9cdfbbc8327afe13ad92714398d