### PR TITLE
Run depmod when kernel modules are installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,10 +288,11 @@ combine coarse-grained `.hook` automation with fine-grained per-package logic.
 ### Kernel installation hook
 
 When a kernel package installs files under `/usr/lib/modules/<version>/`, LPM's
-transaction hook invokes `kernel_install`. The default implementation
-regenerates `/boot/initrd-<version>.img` via `mkinitcpio` (respecting any
-`LPM_PRESET` override) and, if available, updates bootloader entries via
-`bootctl` or `grub-mkconfig`.
+transaction hook invokes `kernel_install`. The default implementation runs
+`depmod` for each affected version, regenerates
+`/boot/initrd-<version>.img` via `mkinitcpio` (respecting any `LPM_PRESET`
+override) and, if available, updates bootloader entries via `bootctl` or
+`grub-mkconfig`.
 
 ## Solver heuristics
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -291,7 +291,7 @@ def test_kernel_install_hook(tmp_path, monkeypatch):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     log = tmp_path / "log"
-    for name in ("mkinitcpio", "bootctl", "grub-mkconfig"):
+    for name in ("depmod", "mkinitcpio", "bootctl", "grub-mkconfig"):
         p = bin_dir / name
         p.write_text(f"#!/bin/sh\necho {name} \"$@\" >> {log}\n")
         p.chmod(0o755)
@@ -310,8 +310,10 @@ def test_kernel_install_hook(tmp_path, monkeypatch):
     )
 
     calls = log.read_text().splitlines()
-    expected = f"mkinitcpio -r {root} -k {version} -g {root / 'boot' / f'initrd-{version}.img'}"
-    assert expected in calls
+    depmod_call = f"depmod -b {root} {version}"
+    mkinitcpio_call = f"mkinitcpio -r {root} -k {version} -g {root / 'boot' / f'initrd-{version}.img'}"
+    assert depmod_call in calls
+    assert mkinitcpio_call in calls
     assert "bootctl update" in calls
     assert "grub-mkconfig -o /boot/grub/grub.cfg" in calls
 
@@ -323,7 +325,7 @@ def test_kernel_install_transaction_hook(tmp_path, monkeypatch, system_hook_dir)
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     log = tmp_path / "kernel.log"
-    for name in ("mkinitcpio", "bootctl", "grub-mkconfig"):
+    for name in ("depmod", "mkinitcpio", "bootctl", "grub-mkconfig"):
         p = bin_dir / name
         p.write_text(f"#!/bin/sh\necho {name} \"$@\" >> {log}\n")
         p.chmod(0o755)
@@ -343,8 +345,10 @@ def test_kernel_install_transaction_hook(tmp_path, monkeypatch, system_hook_dir)
     txn.run_post_transaction()
 
     calls = log.read_text().splitlines()
-    expected = f"mkinitcpio -r {root} -k {version} -g {root / 'boot' / f'initrd-{version}.img'}"
-    assert expected in calls
+    depmod_call = f"depmod -b {root} {version}"
+    mkinitcpio_call = f"mkinitcpio -r {root} -k {version} -g {root / 'boot' / f'initrd-{version}.img'}"
+    assert depmod_call in calls
+    assert mkinitcpio_call in calls
     assert "bootctl update" in calls
     assert "grub-mkconfig -o /boot/grub/grub.cfg" in calls
 
@@ -356,7 +360,7 @@ def test_kernel_modules_install_transaction_hook(tmp_path, monkeypatch, system_h
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     log = tmp_path / "kernel.log"
-    for name in ("mkinitcpio", "bootctl", "grub-mkconfig"):
+    for name in ("depmod", "mkinitcpio", "bootctl", "grub-mkconfig"):
         p = bin_dir / name
         p.write_text(f"#!/bin/sh\necho {name} \"$@\" >> {log}\n")
         p.chmod(0o755)
@@ -376,8 +380,10 @@ def test_kernel_modules_install_transaction_hook(tmp_path, monkeypatch, system_h
     txn.run_post_transaction()
 
     calls = log.read_text().splitlines()
-    expected = f"mkinitcpio -r {root} -k {version} -g {root / 'boot' / f'initrd-{version}.img'}"
-    assert expected in calls
+    depmod_call = f"depmod -b {root} {version}"
+    mkinitcpio_call = f"mkinitcpio -r {root} -k {version} -g {root / 'boot' / f'initrd-{version}.img'}"
+    assert depmod_call in calls
+    assert mkinitcpio_call in calls
     assert "bootctl update" in calls
     assert "grub-mkconfig -o /boot/grub/grub.cfg" in calls
 

--- a/usr/libexec/lpm/hooks/kernel-install
+++ b/usr/libexec/lpm/hooks/kernel-install
@@ -71,6 +71,14 @@ def _run_mkinitcpio(root: Path, version: str) -> None:
     subprocess.run(args, check=True)
 
 
+def _run_depmod(root: Path, version: str) -> None:
+    args = ["depmod"]
+    if root != Path("/"):
+        args.extend(["-b", str(root)])
+    args.append(version)
+    subprocess.run(args, check=True)
+
+
 def _run_preset(root: Path, preset: str) -> None:
     args = ["mkinitcpio"]
     if root != Path("/"):
@@ -89,6 +97,7 @@ def main(argv: List[str] | None = None) -> None:
 
     ran_any = False
     for version in versions:
+        _run_depmod(root, version)
         _run_mkinitcpio(root, version)
         ran_any = True
 


### PR DESCRIPTION
## Summary
- invoke depmod for each kernel version detected by the kernel-install hook before rebuilding initrds
- extend hook tests to stub depmod and assert it is executed alongside mkinitcpio
- update the README to document that depmod now runs during kernel installs

## Testing
- pytest tests/test_hooks.py::test_kernel_install_hook tests/test_hooks.py::test_kernel_install_transaction_hook tests/test_hooks.py::test_kernel_modules_install_transaction_hook *(fails: missing zstandard module in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5caed26648327b4a4d618e6e14527