### PR TITLE
Handle large hook target lists via environment fallback

### DIFF
--- a/usr/libexec/lpm/hooks/_targets.py
+++ b/usr/libexec/lpm/hooks/_targets.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+from typing import Iterable, List
+
+
+def _dedupe(items: Iterable[str]) -> List[str]:
+    seen = set()
+    order: List[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            order.append(item)
+    return order
+
+
+def collect_targets(argv: Iterable[str]) -> List[str]:
+    """Return target paths from the environment and positional arguments."""
+
+    values: List[str] = []
+    env_targets = os.environ.get("LPM_TARGETS", "")
+    if env_targets:
+        for line in env_targets.splitlines():
+            text = line.strip()
+            if text:
+                values.append(text)
+    for arg in argv:
+        text = str(arg).strip()
+        if text:
+            values.append(text)
+    return _dedupe(values)
+

--- a/usr/libexec/lpm/hooks/gdk-pixbuf-query-loaders
+++ b/usr/libexec/lpm/hooks/gdk-pixbuf-query-loaders
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from typing import Iterable, List, Set, Tuple
 
+from _targets import collect_targets
+
 
 def _iter_loader_dirs(root: Path, targets: Iterable[str]) -> List[Tuple[Path, Path]]:
     seen: Set[Path] = set()
@@ -38,7 +40,7 @@ def main(argv: List[str]) -> None:
     if not tool:
         return
     root = Path(os.environ.get("LPM_ROOT", "/"))
-    for module_dir, module_file in _iter_loader_dirs(root, argv):
+    for module_dir, module_file in _iter_loader_dirs(root, collect_targets(argv)):
         env = os.environ.copy()
         env.update(
             {

--- a/usr/libexec/lpm/hooks/gio-querymodules
+++ b/usr/libexec/lpm/hooks/gio-querymodules
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from typing import Iterable, List, Set, Tuple
 
+from _targets import collect_targets
+
 
 def _iter_module_dirs(root: Path, targets: Iterable[str]) -> List[Tuple[Path, Path]]:
     seen: Set[Path] = set()
@@ -37,7 +39,7 @@ def main(argv: List[str]) -> None:
     if not tool:
         return
     root = Path(os.environ.get("LPM_ROOT", "/"))
-    modules = _iter_module_dirs(root, argv)
+    modules = _iter_module_dirs(root, collect_targets(argv))
     for module_dir, rel_dir in modules:
         output = root / rel_dir / "giomodule.cache"
         subprocess.run(

--- a/usr/libexec/lpm/hooks/glib-compile-schemas
+++ b/usr/libexec/lpm/hooks/glib-compile-schemas
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from typing import Iterable, List, Set
 
+from _targets import collect_targets
+
 
 def _iter_schema_dirs(root: Path, targets: Iterable[str]) -> List[Path]:
     seen: Set[Path] = set()
@@ -30,7 +32,7 @@ def main(argv: List[str]) -> None:
     if not tool:
         return
     root = Path(os.environ.get("LPM_ROOT", "/"))
-    for directory in _iter_schema_dirs(root, argv):
+    for directory in _iter_schema_dirs(root, collect_targets(argv)):
         subprocess.run(
             [tool, f"--targetdir={directory}", str(directory)],
             check=False,

--- a/usr/libexec/lpm/hooks/kernel-install
+++ b/usr/libexec/lpm/hooks/kernel-install
@@ -8,30 +8,7 @@ import sys
 from pathlib import Path
 from typing import Iterable, List
 
-
-def _dedupe(items: Iterable[str]) -> List[str]:
-    seen = set()
-    order: List[str] = []
-    for item in items:
-        if item not in seen:
-            seen.add(item)
-            order.append(item)
-    return order
-
-
-def _collect_target_paths(argv: Iterable[str]) -> List[str]:
-    env_targets = os.environ.get("LPM_TARGETS", "")
-    values: List[str] = []
-    if env_targets:
-        for line in env_targets.splitlines():
-            line = line.strip()
-            if line:
-                values.append(line)
-    for arg in argv:
-        text = str(arg).strip()
-        if text:
-            values.append(text)
-    return _dedupe(values)
+from _targets import collect_targets
 
 
 def _extract_module_version(target: str) -> str | None:
@@ -51,14 +28,20 @@ def _extract_module_version(target: str) -> str | None:
 
 def _collect_versions(argv: Iterable[str]) -> List[str]:
     versions: List[str] = []
-    for target in _collect_target_paths(argv):
+    for target in collect_targets(argv):
         version = _extract_module_version(target)
         if version:
             versions.append(version)
     env_version = os.environ.get("LPM_VERSION", "").strip()
     if env_version:
         versions.append(env_version)
-    return _dedupe(versions)
+    seen = set()
+    ordered: List[str] = []
+    for value in versions:
+        if value not in seen:
+            seen.add(value)
+            ordered.append(value)
+    return ordered
 
 
 def _run_mkinitcpio(root: Path, version: str) -> None:

--- a/usr/libexec/lpm/hooks/update-desktop-database
+++ b/usr/libexec/lpm/hooks/update-desktop-database
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from typing import Iterable, List, Set
 
+from _targets import collect_targets
+
 
 def _iter_application_dirs(root: Path, targets: Iterable[str]) -> List[Path]:
     seen: Set[Path] = set()
@@ -35,7 +37,7 @@ def main(argv: List[str]) -> None:
     if not tool:
         return
     root = Path(os.environ.get("LPM_ROOT", "/"))
-    targets = _iter_application_dirs(root, argv)
+    targets = _iter_application_dirs(root, collect_targets(argv))
     for directory in targets:
         subprocess.run([tool, str(directory)], check=False)
 

--- a/usr/libexec/lpm/hooks/update-icon-cache
+++ b/usr/libexec/lpm/hooks/update-icon-cache
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from typing import Iterable, List, Set
 
+from _targets import collect_targets
+
 
 def _iter_icon_dirs(root: Path, targets: Iterable[str]) -> List[Path]:
     seen: Set[Path] = set()
@@ -37,7 +39,7 @@ def main(argv: List[str]) -> None:
     if not tool:
         return
     root = Path(os.environ.get("LPM_ROOT", "/"))
-    targets = _iter_icon_dirs(root, argv)
+    targets = _iter_icon_dirs(root, collect_targets(argv))
     for directory in targets:
         subprocess.run([tool, str(directory)], check=False)
 

--- a/usr/libexec/lpm/hooks/update-mime-database
+++ b/usr/libexec/lpm/hooks/update-mime-database
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from typing import Iterable, List, Set
 
+from _targets import collect_targets
+
 
 def _iter_mime_dirs(root: Path, targets: Iterable[str]) -> List[Path]:
     seen: Set[Path] = set()
@@ -40,7 +42,7 @@ def main(argv: List[str]) -> None:
     if not tool:
         return
     root = Path(os.environ.get("LPM_ROOT", "/"))
-    targets = _iter_mime_dirs(root, argv)
+    targets = _iter_mime_dirs(root, collect_targets(argv))
     for directory in targets:
         subprocess.run([tool, str(directory)], check=False)
 


### PR DESCRIPTION
## Summary
- retry hook execution without positional targets when the argument list exceeds system limits
- add a shared helper that merges hook targets from the environment and argv inputs
- update built-in hook scripts to consume targets from the helper so they still work when argv is trimmed

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'zstandard')*


------
https://chatgpt.com/codex/tasks/task_e_68e5d374cdcc832794bc3b7487c6096d