### PR TITLE
Handle large hook target lists via temp file fallback

### DIFF
--- a/usr/libexec/lpm/hooks/_targets.py
+++ b/usr/libexec/lpm/hooks/_targets.py
@@ -5,6 +5,14 @@ import os
 from typing import Iterable, List
 
 
+def _iter_file_lines(path: str) -> Iterable[str]:
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            yield from fh
+    except OSError:
+        return
+
+
 def _dedupe(items: Iterable[str]) -> List[str]:
     seen = set()
     order: List[str] = []
@@ -20,6 +28,12 @@ def collect_targets(argv: Iterable[str]) -> List[str]:
 
     values: List[str] = []
     env_targets = os.environ.get("LPM_TARGETS", "")
+    env_targets_file = os.environ.get("LPM_TARGETS_FILE", "")
+    if env_targets_file:
+        for line in _iter_file_lines(env_targets_file):
+            text = line.strip()
+            if text:
+                values.append(text)
     if env_targets:
         for line in env_targets.splitlines():
             text = line.strip()


### PR DESCRIPTION
## Summary
- retry hook execution with targets stored in a temporary file when argument limits are exceeded
- teach hook helpers to read target lists from the temporary file path when provided

## Testing
- pytest *(fails: missing optional dependency `zstandard` in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5da09dcd8832794f77c5f3811544c