### PR TITLE
Add automated maintenance hook for post-transaction cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The Linux Package Manager
   pruning (`MAX_SNAPSHOTS` in `lpm.conf`) and rollback support.
 - **Bootstrap mode** to build a minimal chroot and populate it with verified
   packages.
+- **Automated maintenance hooks** that run `lpm autoremove`, prune snapshots,
+  and clean the cache after each transaction to keep systems tidy.【F:usr/libexec/lpm/hooks/system-maintenance†L1-L49】【F:usr/share/liblpm/hooks/system-maintenance.hook†L1-L10】
 - **Incremental SAT solver API** available for other tools and benchmarks in
   `benchmarks/solver_bench.py`.
 - **.lpmbuild scripts** for reproducible package builds and a `build` command to

--- a/docs/TECHNICAL-HOWTO.md
+++ b/docs/TECHNICAL-HOWTO.md
@@ -203,6 +203,11 @@ Computes and removes orphaned dependencies that are no longer required by any
 explicitly installed package. Supports `--root` and `--dry-run` just like
 `remove`.【F:lpm.py†L2162-L2166】
 
+All package transactions automatically trigger the system-maintenance hook,
+which runs `lpm autoremove --root "$LPM_ROOT"` plus snapshot pruning and cache
+cleaning for the real root, keeping orphaned packages and stale data from
+accumulating between manual maintenance sessions.【F:usr/libexec/lpm/hooks/system-maintenance†L1-L49】【F:usr/share/liblpm/hooks/system-maintenance.hook†L1-L10】
+
 ```bash
 $ sudo lpm autoremove
 ```

--- a/usr/libexec/lpm/hooks/system-maintenance
+++ b/usr/libexec/lpm/hooks/system-maintenance
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Run post-transaction maintenance tasks for LPM."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from typing import Iterable, List
+
+
+def _find_lpm() -> str | None:
+    return shutil.which("lpm")
+
+
+def _build_tasks(lpm_path: str, root: str) -> List[List[str]]:
+    tasks: List[List[str]] = [[lpm_path, "autoremove", "--root", root]]
+    if root in {"", "/"}:
+        tasks.append([lpm_path, "snapshots", "--prune"])
+        tasks.append([lpm_path, "clean"])
+    return tasks
+
+
+def _run_tasks(commands: Iterable[List[str]], env: dict[str, str]) -> None:
+    for argv in commands:
+        try:
+            subprocess.run(argv, check=False, env=env)
+        except FileNotFoundError:
+            # If a command disappears mid-transaction, abort further runs.
+            return
+        except Exception as exc:  # pragma: no cover - best effort logging only
+            print(
+                f"[lpm-maintenance] failed to run {' '.join(argv)}: {exc}",
+                file=sys.stderr,
+            )
+
+
+def main() -> None:
+    if os.environ.get("LPM_SKIP_MAINTENANCE") == "1":
+        return
+
+    lpm_path = _find_lpm()
+    if not lpm_path:
+        return
+
+    root = os.environ.get("LPM_ROOT", "/") or "/"
+    env = dict(os.environ)
+    env["LPM_SKIP_MAINTENANCE"] = "1"
+
+    tasks = _build_tasks(lpm_path, root)
+    _run_tasks(tasks, env)
+
+
+if __name__ == "__main__":
+    main()

--- a/usr/share/liblpm/hooks/system-maintenance.hook
+++ b/usr/share/liblpm/hooks/system-maintenance.hook
@@ -1,0 +1,10 @@
+[Trigger]
+Type = Package
+Operation = Install
+Operation = Upgrade
+Operation = Remove
+Target = *
+
+[Action]
+When = PostTransaction
+Exec = /usr/libexec/lpm/hooks/system-maintenance


### PR DESCRIPTION
## Summary
- add a system-maintenance hook that runs autoremove, snapshot pruning, and cache cleaning after package transactions
- expose liblpmhooks under src.liblpmhooks.__init__ so monkeypatch-based tests can target helper functions
- document the automated maintenance workflow in the README and technical how-to guide

## Testing
- pytest tests/test_hooks.py

------
https://chatgpt.com/codex/tasks/task_e_68e68a5817488327b6ea7a7089ddbf58