### PR TITLE
Cap URL downloads, add logging and respect configured umask, and make lockfile chmod best-effort

### DIFF
--- a/src/fs.py
+++ b/src/fs.py
@@ -43,13 +43,18 @@ def _content_disposition_filename(header: str | None) -> Optional[str]:
 
 
 def urlread(url: str, timeout: float | None = 10) -> Tuple[bytes, Optional[str]]:
+    max_download = 1 << 30  # 1 GiB hard safety cap
     try:
         with urllib.request.urlopen(url, timeout=timeout) as r:
             meta_filename = _content_disposition_filename(r.headers.get("content-disposition"))
             final_url = r.geturl()
             total = int(r.headers.get("content-length", 0) or 0)
+            if total > max_download:
+                raise RuntimeError(f"Refusing to download content larger than {max_download} bytes")
             if total == 0:
                 data = r.read()
+                if len(data) > max_download:
+                    raise RuntimeError(f"Refusing to download content larger than {max_download} bytes")
                 return data, meta_filename or final_url
             chunk_size = 1 << 14
             data = bytearray()
@@ -59,6 +64,8 @@ def urlread(url: str, timeout: float | None = 10) -> Tuple[bytes, Optional[str]]
                     if not chunk:
                         break
                     data.extend(chunk)
+                    if len(data) > max_download:
+                        raise RuntimeError(f"Refusing to download content larger than {max_download} bytes")
                     bar.update(len(chunk))
             return bytes(data), meta_filename or final_url
     except urllib.error.URLError as e:

--- a/src/lpm/atomic_io.py
+++ b/src/lpm/atomic_io.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import os
 import tempfile
+import logging
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterable, Iterator, Optional, Union
 
 
 BytesLike = Union[bytes, bytearray, memoryview]
+logger = logging.getLogger(__name__)
 
 
 def _coerce_bytes(data: Union[str, BytesLike], *, encoding: str = "utf-8") -> bytes:
@@ -61,11 +63,9 @@ def enforce_umask(mask: int) -> Iterator[None]:
 
 
 def _current_umask() -> int:
-    """Return the process' current umask without permanently altering it."""
-
-    current = os.umask(0)
-    os.umask(current)
-    return current
+    """Return configured umask used for write-mode calculations."""
+    from . import config
+    return config.UMASK
 
 
 def read_bytes(path: Union[str, Path]) -> bytes:
@@ -88,8 +88,8 @@ def _apply_metadata(
     applied_mode = requested & ~mask
     try:
         os.chmod(tmp_path, applied_mode)
-    except OSError:
-        pass
+    except OSError as exc:
+        logger.debug("failed chmod on temp file %s: %s", tmp_path, exc)
 
     os.replace(tmp_path, target)
 
@@ -98,18 +98,18 @@ def _apply_metadata(
         gid = group if group is not None else -1
         try:
             os.chown(target, uid, gid)
-        except OSError:
-            pass
+        except OSError as exc:
+            logger.debug("failed chown on %s to %s:%s: %s", target, uid, gid, exc)
 
     try:
         os.chmod(target, applied_mode)
-    except OSError:
-        pass
+    except OSError as exc:
+        logger.debug("failed chmod on target %s: %s", target, exc)
 
     try:
         os.utime(target, None)
-    except OSError:
-        pass
+    except OSError as exc:
+        logger.debug("failed utime on target %s: %s", target, exc)
 
     sync_targets = {target.parent}
     for directory in extra_sync:

--- a/src/lpm/locking.py
+++ b/src/lpm/locking.py
@@ -57,8 +57,13 @@ def _acquire(lock_path: Path) -> _LockHandle:
     lock_path.parent.mkdir(parents=True, exist_ok=True)
 
     flags = os.O_RDWR | os.O_CREAT
-    fd = os.open(lock_path, flags, 0o666 & ~config.UMASK)
-    os.chmod(lock_path, 0o666 & ~config.UMASK)
+    mode = 0o666 & ~config.UMASK
+    fd = os.open(lock_path, flags, mode)
+    try:
+        os.chmod(lock_path, mode)
+    except OSError:
+        # Locking still works with the existing permissions; chmod is best-effort.
+        pass
 
     try:
         fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)


### PR DESCRIPTION
### Motivation

- Prevent uncontrolled large downloads from `urlread` by enforcing a hard safety cap.
- Improve observability and make atomic writes honor the configured umask instead of probing the process umask directly.
- Make lockfile permission setting best-effort to avoid raising on platforms where `chmod` may fail.

### Description

- In `src/fs.py` add a `max_download` (1 GiB) hard cap to `urlread` and raise `RuntimeError` if `Content-Length` or actual read bytes exceed the cap.
- In `src/lpm/atomic_io.py` introduce a module `logger`, change `_current_umask` to return `config.UMASK` instead of using `os.umask`, and replace silent `except` blocks in `_apply_metadata` with `logger.debug` messages so failures to `chmod`, `chown`, or `utime` are logged but not fatal.
- In `src/lpm/locking.py` compute and reuse `mode = 0o666 & ~config.UMASK` for the lock file, call `os.open` with that `mode`, and make `os.chmod` a best-effort call wrapped in `try/except` so permission-setting failures do not prevent acquiring the lock.

### Testing

- Ran the test suite with `pytest -q` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03a293f8688327bebb675c68dec0b7)