### PR TITLE
Fix kernel-install failure when initrd file is read-only

### DIFF
--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -528,6 +528,36 @@ def test_kernel_modules_install_transaction_hook(tmp_path, monkeypatch, system_h
     assert "grub-mkconfig -o /boot/grub/grub.cfg" in calls
 
 
+def test_kernel_install_hook_makes_existing_initrd_writable(tmp_path, monkeypatch):
+    hook_dir = Path(__file__).resolve().parent.parent / "usr/share/lpm/hooks"
+    monkeypatch.setattr(lpm, "HOOK_DIR", hook_dir)
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "log"
+    for name in ("depmod", "mkinitcpio", "bootctl", "grub-mkconfig"):
+        p = bin_dir / name
+        p.write_text(f"#!/bin/sh\necho {name} \"$@\" >> {log}\n")
+        p.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+
+    root = tmp_path / "root"
+    initrd = root / "boot" / "initrd-1.2.4-lpm.img"
+    initrd.parent.mkdir(parents=True, exist_ok=True)
+    initrd.write_text("existing")
+    initrd.chmod(0o444)
+
+    lpm.run_hook(
+        "kernel_install",
+        {
+            "LPM_VERSION": "1.2.4-lpm",
+            "LPM_ROOT": str(root),
+        },
+    )
+
+    assert os.access(initrd, os.W_OK)
+
+
 def test_transaction_manager_uses_temp_targets_before_e2big(monkeypatch, tmp_path):
     hook = Hook(
         name="big-targets",

--- a/usr/libexec/lpm/hooks/kernel-install
+++ b/usr/libexec/lpm/hooks/kernel-install
@@ -61,6 +61,8 @@ def _collect_versions(argv: Iterable[str]) -> List[str]:
 def _run_mkinitcpio(root: Path, version: str) -> None:
     output = root / "boot" / f"initrd-{version}.img"
     output.parent.mkdir(parents=True, exist_ok=True)
+    if output.exists() and not os.access(output, os.W_OK):
+        output.chmod(output.stat().st_mode | 0o200)
     args = ["mkinitcpio"]
     if root != Path("/"):
         args.extend(["-r", str(root)])


### PR DESCRIPTION
### Motivation
- Prevent `mkinitcpio` failures when a pre-existing initrd image file lacks write permission, which caused hooks to error with messages like `... must be writable` during kernel package installation.

### Description
- In `usr/libexec/lpm/hooks/kernel-install`, ensure the output initrd file is writable by setting the owner write bit if the file exists and is not writable before invoking `mkinitcpio`.
- Add a regression test `test_kernel_install_hook_makes_existing_initrd_writable` in `tests/test_hooks.py` that creates a read-only initrd, runs the `kernel_install` hook, and asserts the file becomes writable.

### Testing
- Ran `pytest -q tests/test_hooks.py -k "kernel_install_hook and writable"` and the test passed (`1 passed, 14 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05b6ed9fb88327806a85791e53c29c)