### PR TITLE
Add createiso CLI and Qt UI flow for preloaded system images

### DIFF
--- a/src/lpm/app.py
+++ b/src/lpm/app.py
@@ -5397,6 +5397,51 @@ def cmd_genindex(a):
     repo_dir = Path(a.repo_dir)
     gen_index(repo_dir, a.base_url, arch_filter=a.arch)
 
+def cmd_createiso(a):
+    source_root = Path(a.source_root or "/").resolve()
+    output = Path(a.output).resolve()
+    volume_id = a.volume_id.strip() if a.volume_id else "LPM_PRELOAD"
+
+    if not source_root.exists() or not source_root.is_dir():
+        die(f"Source root does not exist or is not a directory: {source_root}")
+    if source_root == Path("/"):
+        log("[lpm] Creating system image from / (excluding transient and user-home paths)")
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    xorriso = shutil.which("xorriso")
+    if not xorriso:
+        die("xorriso is required. Install xorriso and try again.")
+
+    exclusions = [
+        "home",
+        "proc",
+        "sys",
+        "dev",
+        "run",
+        "tmp",
+        "mnt",
+        "media",
+        "lost+found",
+    ]
+    exclude_args = [arg for item in exclusions for arg in ("-m", item)]
+    cmd = [
+        xorriso,
+        "-as",
+        "mkisofs",
+        "-R",
+        "-J",
+        "-V",
+        volume_id,
+        "-o",
+        str(output),
+        *exclude_args,
+        str(source_root),
+    ]
+    res = subprocess.run(cmd, check=False)
+    if res.returncode != 0:
+        die(f"ISO creation failed with exit code {res.returncode}")
+    ok(f"Created ISO image at {output}")
+
 def cmd_clean_cache(_):
     if CACHE_DIR.exists():
         for p in CACHE_DIR.iterdir():
@@ -6425,6 +6470,12 @@ def build_parser()->argparse.ArgumentParser:
     sp.add_argument("--base-url", dest="base_url", help="base URL for blobs in index (e.g., https://repo.example.com)", default=None)
     sp.add_argument("--arch", help="only include this arch (noarch always included)", default=None)
     sp.set_defaults(func=cmd_genindex)
+
+    sp=sub.add_parser("createiso", help="Create a bootable-style recovery ISO from the system with LPM preloaded")
+    sp.add_argument("--source-root", default="/", help="filesystem root to package (default: /)")
+    sp.add_argument("--output", required=True, help="output .iso file path")
+    sp.add_argument("--volume-id", default="LPM_PRELOAD", help="ISO volume identifier")
+    sp.set_defaults(func=cmd_createiso)
 
     if maintainer_mode.is_enabled():
         sp=sub.add_parser("lpmspec", help="Generate an lpmspec description for Nebula installers")

--- a/src/ui/backend.py
+++ b/src/ui/backend.py
@@ -326,6 +326,24 @@ class LPMBackend:
         args = ["installpkg", *files]
         return self.run_cli(args)
 
+    def create_system_iso(
+        self,
+        output: str,
+        *,
+        source_root: str = "/",
+        volume_id: str = "LPM_PRELOAD",
+    ) -> subprocess.CompletedProcess[str]:
+        args = [
+            "createiso",
+            "--source-root",
+            source_root,
+            "--output",
+            output,
+            "--volume-id",
+            volume_id,
+        ]
+        return self.run_cli(args)
+
 
 # ----------------------------------------------------------------------
 def _format_install_time(timestamp: int | None) -> str:

--- a/src/ui/qt_app_impl.py
+++ b/src/ui/qt_app_impl.py
@@ -476,6 +476,12 @@ class LPMWindow(QMainWindow):
         self.package_file_input = QLineEdit()
         self.package_file_button = QPushButton("Browse…")
         self.installpkg_button = QPushButton("Run installpkg")
+        iso_out_label = QLabel("System ISO output file:")
+        self.iso_output_input = QLineEdit()
+        self.iso_output_button = QPushButton("Browse…")
+        iso_volume_label = QLabel("ISO volume id:")
+        self.iso_volume_input = QLineEdit("LPM_PRELOAD")
+        self.create_iso_button = QPushButton("Create system ISO")
 
         layout.addWidget(script_label, 0, 0)
         layout.addWidget(self.build_script_input, 0, 1)
@@ -490,6 +496,12 @@ class LPMWindow(QMainWindow):
         layout.addWidget(self.package_file_input, 4, 1)
         layout.addWidget(self.package_file_button, 4, 2)
         layout.addWidget(self.installpkg_button, 5, 0, 1, 3)
+        layout.addWidget(iso_out_label, 6, 0)
+        layout.addWidget(self.iso_output_input, 6, 1)
+        layout.addWidget(self.iso_output_button, 6, 2)
+        layout.addWidget(iso_volume_label, 7, 0)
+        layout.addWidget(self.iso_volume_input, 7, 1, 1, 2)
+        layout.addWidget(self.create_iso_button, 8, 0, 1, 3)
 
     def _build_log_panel(self) -> None:
         layout = QVBoxLayout(self.log_group)
@@ -677,6 +689,8 @@ class LPMWindow(QMainWindow):
         self.buildpkg_button.clicked.connect(self._run_buildpkg)
         self.package_file_button.clicked.connect(self._browse_package_files)
         self.installpkg_button.clicked.connect(self._run_installpkg)
+        self.iso_output_button.clicked.connect(self._browse_iso_output)
+        self.create_iso_button.clicked.connect(self._run_create_iso)
 
     # ------------------------------------------------------------------
     # Worker helpers
@@ -989,6 +1003,30 @@ class LPMWindow(QMainWindow):
             on_result=self._handle_cli_result,
             on_finished=self._refresh_installed,
             status="Installing local packages…",
+        )
+
+    def _browse_iso_output(self) -> None:
+        filename, _ = QFileDialog.getSaveFileName(
+            self,
+            "Save system ISO image",
+            "lpm-preloaded.iso",
+            "ISO images (*.iso);;All files (*)",
+        )
+        if filename:
+            self.iso_output_input.setText(filename)
+
+    def _run_create_iso(self) -> None:
+        output = self.iso_output_input.text().strip()
+        if not output:
+            QMessageBox.information(self, "createiso", "Choose an output .iso file path.")
+            return
+        volume_id = self.iso_volume_input.text().strip() or "LPM_PRELOAD"
+        self._run_task(
+            self.backend.create_system_iso,
+            output,
+            on_result=self._handle_cli_result,
+            status="Creating system ISO…",
+            volume_id=volume_id,
         )
 
 

--- a/tests/test_createiso.py
+++ b/tests/test_createiso.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from src.lpm.app import build_parser
+from src.ui.backend import LPMBackend
+
+
+def test_createiso_parser_wires_command():
+    parser = build_parser()
+    args = parser.parse_args(["createiso", "--output", "/tmp/system.iso"])
+    assert args.cmd == "createiso"
+    assert args.source_root == "/"
+    assert args.output == "/tmp/system.iso"
+    assert args.volume_id == "LPM_PRELOAD"
+    assert args.func.__name__ == "cmd_createiso"
+
+
+def test_backend_create_system_iso_builds_cli_args(monkeypatch):
+    backend = LPMBackend()
+    captured: dict[str, object] = {}
+
+    def _fake_run_cli(args, *, root=None):
+        captured["args"] = list(args)
+        captured["root"] = root
+        return object()
+
+    monkeypatch.setattr(backend, "run_cli", _fake_run_cli)
+    backend.create_system_iso("/tmp/system.iso", source_root="/", volume_id="LPM_PRELOAD")
+    assert captured["args"] == [
+        "createiso",
+        "--source-root",
+        "/",
+        "--output",
+        "/tmp/system.iso",
+        "--volume-id",
+        "LPM_PRELOAD",
+    ]
+    assert captured["root"] is None


### PR DESCRIPTION
### Motivation
- Provide a way to produce a bootable-style ISO of the current system with LPM and its configs preloaded while excluding user home and transient runtime filesystems to emulate a fresh install.
- Expose the capability both from the CLI and the existing Qt UI so users can create recovery/install media without touching home directories.

### Description
- Added `cmd_createiso` in `src/lpm/app.py` which validates a `--source-root`, requires `xorriso`, builds an `xorriso -as mkisofs` command, and excludes `home`, `proc`, `sys`, `dev`, `run`, `tmp`, `mnt`, `media`, and `lost+found` paths before writing the ISO.
- Registered the `createiso` subcommand in the CLI parser with `--source-root`, `--output`, and `--volume-id` flags and wired it to `cmd_createiso` in `build_parser`.
- Added `LPMBackend.create_system_iso(...)` in `src/ui/backend.py` which constructs the CLI args and invokes `run_cli` to integrate with the UI background task workflow.
- Extended the Qt UI in `src/ui/qt_app_impl.py` with input widgets and handlers to pick an output path, set the ISO volume id, and start ISO creation via `create_system_iso` with status/log reporting.
- Added focused tests in `tests/test_createiso.py` to assert the parser wiring and that the backend composes the expected CLI arguments.

### Testing
- Ran `pytest -q tests/test_createiso.py` and both tests passed (`2 passed`).
- The new tests validate `build_parser()` wiring for `createiso` and that `LPMBackend.create_system_iso` calls `run_cli` with the expected argument list.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a071e6b2e44832797809cd129d249ae)