### PR TITLE
Add in-process mutex around global transaction file lock

### DIFF
--- a/src/lpm/locking.py
+++ b/src/lpm/locking.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -8,6 +9,8 @@ from typing import Optional
 import fcntl
 
 from . import config
+
+_INPROC_TXN_LOCK = threading.RLock()
 
 
 class TransactionLockError(RuntimeError):
@@ -86,13 +89,21 @@ class GlobalTransactionLock:
         self._handle: Optional[_LockHandle] = None
 
     def __enter__(self) -> "GlobalTransactionLock":
-        self._handle = _acquire(self.path)
+        _INPROC_TXN_LOCK.acquire()
+        try:
+            self._handle = _acquire(self.path)
+        except Exception:
+            _INPROC_TXN_LOCK.release()
+            raise
         return self
 
     def __exit__(self, exc_type, exc, tb) -> None:
-        if self._handle is not None:
-            self._handle.release()
-            self._handle = None
+        try:
+            if self._handle is not None:
+                self._handle.release()
+                self._handle = None
+        finally:
+            _INPROC_TXN_LOCK.release()
 
 
 def global_transaction_lock(path: Optional[Path] = None) -> GlobalTransactionLock:

--- a/tests/test_transaction_lock.py
+++ b/tests/test_transaction_lock.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import importlib
 import os
 import sqlite3
+import threading
+import time
 
 import pytest
 
@@ -65,3 +67,35 @@ def test_transaction_context_rejects_when_locked(isolated_state, capsys):
     assert exc.value.code == 2
     captured = capsys.readouterr()
     assert "another transaction is running" in captured.err
+
+
+def test_transaction_lock_serializes_threads_in_process(isolated_state):
+    _, locking, _ = isolated_state
+    entered_second = threading.Event()
+    release_first = threading.Event()
+    done_second = threading.Event()
+
+    def first_holder():
+        with locking.global_transaction_lock():
+            release_first.wait(timeout=2)
+
+    def second_holder():
+        with locking.global_transaction_lock():
+            entered_second.set()
+        done_second.set()
+
+    first = threading.Thread(target=first_holder)
+    second = threading.Thread(target=second_holder)
+
+    first.start()
+    time.sleep(0.05)
+    second.start()
+
+    time.sleep(0.1)
+    assert not entered_second.is_set()
+
+    release_first.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert done_second.is_set()


### PR DESCRIPTION
### Motivation
- Ensure that threads within the same process serialize access to the global transaction facility so two threads cannot race when obtaining the OS-level file lock.

### Description
- Import `threading` and add a module-level reentrant lock `_INPROC_TXN_LOCK = threading.RLock()` in `src/lpm/locking.py`.
- Acquire `_INPROC_TXN_LOCK` in `GlobalTransactionLock.__enter__` before calling `_acquire(self.path)` and release it if `_acquire` raises.
- In `GlobalTransactionLock.__exit__`, release the file lock handle first and always release `_INPROC_TXN_LOCK` in a `finally` block.
- Add `test_transaction_lock_serializes_threads_in_process` in `tests/test_transaction_lock.py` which spawns two threads to validate same-process serialization of the transaction lock.

### Testing
- Ran `pytest -q tests/test_transaction_lock.py` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a087713c168832787eff5620babc6cb)