### PR TITLE
Add thread-safe synchronization to HookTransactionManager

### DIFF
--- a/src/lpm/hooks/__init__.py
+++ b/src/lpm/hooks/__init__.py
@@ -8,6 +8,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import threading
 from dataclasses import dataclass, field
 from fnmatch import fnmatch
 from pathlib import Path
@@ -254,6 +255,7 @@ class HookTransactionManager:
         self.root = Path(root)
         self.base_env = dict(base_env or {})
         self.events: List[_TransactionEvent] = []
+        self._lock = threading.RLock()
         self._pre_ran = False
         self._post_ran = False
 
@@ -266,38 +268,43 @@ class HookTransactionManager:
         release: Optional[str],
         paths: Iterable[str],
     ) -> None:
-        op = operation.capitalize()
-        if op not in _VALID_OPS:
-            raise HookError(f"Unsupported operation {operation!r}")
-        cleaned_paths = _dedupe_preserve_order(_normalize_path(p) for p in paths)
-        self.events.append(
-            _TransactionEvent(
-                name=name,
-                operation=op,
-                version=version,
-                release=release,
-                paths=cleaned_paths,
+        with self._lock:
+            op = operation.capitalize()
+            if op not in _VALID_OPS:
+                raise HookError(f"Unsupported operation {operation!r}")
+            cleaned_paths = _dedupe_preserve_order(_normalize_path(p) for p in paths)
+            self.events.append(
+                _TransactionEvent(
+                    name=name,
+                    operation=op,
+                    version=version,
+                    release=release,
+                    paths=cleaned_paths,
+                )
             )
-        )
 
     def ensure_pre_transaction(self) -> None:
-        if not self._pre_ran:
-            self._run_when("PreTransaction")
+        with self._lock:
+            if self._pre_ran:
+                return
             self._pre_ran = True
+        self._run_when("PreTransaction")
 
     def run_post_transaction(self) -> None:
-        if not self._post_ran:
+        with self._lock:
+            if self._post_ran:
+                return
             if not self._pre_ran:
                 # If post is requested without pre, still mark pre as executed so
                 # hooks relying solely on post run correctly.
                 self._pre_ran = True
-            self._run_when("PostTransaction")
             self._post_ran = True
+        self._run_when("PostTransaction")
 
     # ------------------------------------------------------------------
-    def _gather_matches(self, trigger: HookTrigger) -> List[str]:
+    def _gather_matches(self, trigger: HookTrigger, events: Sequence[_TransactionEvent]) -> List[str]:
         matches: List[str] = []
-        for event in self.events:
+        for event in events:
             if event.operation not in trigger.operations:
                 continue
             if trigger.type == "Package":
@@ -316,20 +323,25 @@ class HookTransactionManager:
                             break
         return matches
 
-    def _iter_triggered(self, when: str) -> Iterator[tuple[Hook, List[str]]]:
+    def _iter_triggered(self, when: str, events: Sequence[_TransactionEvent]) -> Iterator[tuple[Hook, List[str]]]:
         for hook in self.hooks.values():
             if hook.action.when != when:
                 continue
             targets: List[str] = []
             for trigger in hook.triggers:
-                matches = self._gather_matches(trigger)
+                matches = self._gather_matches(trigger, events)
                 if matches:
                     targets.extend(matches)
             if targets:
                 yield hook, _dedupe_preserve_order(targets)
 
+    def _snapshot_triggered(self, when: str) -> List[tuple[Hook, List[str]]]:
+        with self._lock:
+            events_snapshot = list(self.events)
+            return list(self._iter_triggered(when, events_snapshot))
+
     def _run_when(self, when: str) -> None:
-        triggered: List[tuple[Hook, List[str]]] = list(self._iter_triggered(when))
+        triggered: List[tuple[Hook, List[str]]] = self._snapshot_triggered(when)
         if not triggered:
             return
         ordered = self._order_by_dependencies(triggered)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -33,7 +33,7 @@ if "tqdm" not in sys.modules:
 
 import lpm
 import pytest
-from src.lpm.hooks import Hook, HookAction, HookTransactionManager, load_hooks
+from src.lpm.hooks import Hook, HookAction, HookTransactionManager, HookTrigger, load_hooks
 
 
 def test_python_hook(tmp_path, monkeypatch):
@@ -750,3 +750,75 @@ def test_transaction_manager_failure_handling(tmp_path):
     txn = HookTransactionManager(hooks=hooks, root=root)
     txn.add_package_event(name="failpkg", operation="Install", version="1", release="1", paths=["/tmp/file"])
     txn.ensure_pre_transaction()
+
+
+def test_transaction_manager_thread_safety(monkeypatch):
+    import threading
+
+    hooks = {
+        "pkg-pre": Hook(
+            name="pkg-pre",
+            path=Path("/tmp/pkg-pre.hook"),
+            triggers=[HookTrigger(type="Package", operations={"Install"}, targets=["pkg*"])],
+            action=HookAction(when="PreTransaction", exec=["/bin/true"], needs_targets=True),
+        ),
+        "path-post": Hook(
+            name="path-post",
+            path=Path("/tmp/path-post.hook"),
+            triggers=[HookTrigger(type="Path", operations={"Install"}, targets=["usr/bin/*"])],
+            action=HookAction(when="PostTransaction", exec=["/bin/true"], needs_targets=True),
+        ),
+    }
+    txn = HookTransactionManager(hooks=hooks, root=Path("/"))
+
+    failures = []
+    run_calls = []
+    run_lock = threading.Lock()
+
+    def fake_run_hook(hook, targets):
+        with run_lock:
+            run_calls.append((hook.name, tuple(targets)))
+
+    monkeypatch.setattr(txn, "_run_hook", fake_run_hook)
+
+    workers = []
+
+    def add_event(i):
+        try:
+            txn.add_package_event(
+                name=f"pkg{i}",
+                operation="Install",
+                version="1.0",
+                release="1",
+                paths=[f"/usr/bin/tool{i}", "/usr/bin/tool-common"],
+            )
+        except Exception as exc:  # pragma: no cover - should never happen
+            failures.append(exc)
+
+    for i in range(24):
+        workers.append(threading.Thread(target=add_event, args=(i,)))
+    for _ in range(8):
+        workers.append(threading.Thread(target=lambda: txn.ensure_pre_transaction()))
+        workers.append(threading.Thread(target=lambda: txn.run_post_transaction()))
+
+    for t in workers:
+        t.start()
+    for t in workers:
+        t.join()
+
+    txn.ensure_pre_transaction()
+    txn.run_post_transaction()
+
+    assert failures == []
+
+    pre_calls = [targets for name, targets in run_calls if name == "pkg-pre"]
+    post_calls = [targets for name, targets in run_calls if name == "path-post"]
+
+    assert len(pre_calls) == 1
+    assert len(post_calls) == 1
+
+    expected_pkg_targets = {f"pkg{i}-1.0-1" for i in range(24)}
+    assert set(pre_calls[0]) == expected_pkg_targets
+
+    expected_path_targets = {f"/usr/bin/tool{i}" for i in range(24)} | {"/usr/bin/tool-common"}
+    assert set(post_calls[0]) == expected_path_targets


### PR DESCRIPTION
### Motivation
- Prevent races and inconsistent reads/writes of mutable transaction state in `HookTransactionManager` when events and pre/post transitions are manipulated concurrently.
- Ensure `_pre_ran`/`_post_ran` transitions are atomic and that trigger evaluation observes a stable snapshot of `self.events`.
- Reduce the duration of critical sections by running external hook subprocesses outside of locks to avoid blocking other threads.

### Description
- Import `threading` and add `self._lock = threading.RLock()` in `HookTransactionManager.__init__`, and guard mutations to `self.events` with the lock (notably in `add_package_event`).
- Make `ensure_pre_transaction` and `run_post_transaction` perform check-and-set for `_pre_ran`/`_post_ran` under the lock and execute hook dispatch outside the lock to keep critical sections short.
- Change `_gather_matches`/`_iter_triggered` to accept an explicit `events` snapshot and add `_snapshot_triggered` to capture `self.events` under lock so trigger evaluation is deterministic.

### Testing
- Added `test_transaction_manager_thread_safety` to `tests/test_hooks.py` which concurrently calls `add_package_event`, `ensure_pre_transaction`, and `run_post_transaction` and verifies pre/post hooks run once, target sets are deterministic, and no exceptions occur.
- Ran `pytest -q tests/test_hooks.py -k thread_safety` which passed (`1 passed, 15 deselected`).
- Ran the full file with `pytest -q tests/test_hooks.py` which passed (`16 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0877a3936083279ac39a3c67dab5a4)