### PR TITLE
Forward hook_failure_mode to installpkg in file-install worker

### DIFF
--- a/src/lpm/app.py
+++ b/src/lpm/app.py
@@ -5523,6 +5523,7 @@ def cmd_fileinstall(a):
             verify=a.verify,
             force=a.force,
             explicit=True,
+            hook_failure_mode=getattr(a, "hook_failure_mode", HookFailureMode.STRICT),
         )
 
     max_workers = min(8, len(files))


### PR DESCRIPTION
### Motivation
- Fix a `NameError` when running `lpm installpkg` caused by the file-install worker not forwarding `hook_failure_mode` to `installpkg`.

### Description
- Added `hook_failure_mode=getattr(a, "hook_failure_mode", HookFailureMode.STRICT)` to the `installpkg(...)` call in `cmd_fileinstall` in `src/lpm/app.py` so the CLI-parsed value is forwarded with a safe default.

### Testing
- Ran `python -m py_compile src/lpm/app.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a098d0c9d748327a92d2701aaef67b7)