### PR TITLE
Add missing hook_failure_mode parameter to installpkg to fix NameError

### DIFF
--- a/src/lpm/app.py
+++ b/src/lpm/app.py
@@ -5625,6 +5625,7 @@ def installpkg(
     force: bool = False,
     explicit: bool = False,
     allow_fallback: bool = ALLOW_LPMBUILD_FALLBACK,
+    hook_failure_mode: str = HookFailureMode.STRICT,
     hook_transaction: Optional[HookTransactionManager] = None,
     register_event: bool = True,
 ) -> PkgMeta | List[PkgMeta]:


### PR DESCRIPTION
### Motivation
- `installpkg` referenced `hook_failure_mode` when creating hook transaction state but the parameter was not declared, causing a runtime `NameError` during dependency installation flows (e.g. when `prompt_install_pkg` invoked `installpkg`).

### Description
- Add the `hook_failure_mode: str = HookFailureMode.STRICT` parameter to the `installpkg(...)` signature so internal hook transaction setup can access it.

### Testing
- Ran `pytest -q tests/test_run_lpmbuild_dependencies.py` which completed with `12 passed` (and a few warnings).
- Attempted to run specific test node IDs with `pytest -q` but those node selections did not match any tests and therefore no tests were run for that invocation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0993a39c388327bc2215c2169ee91d)