### PR TITLE
Implement atomic package replacement on upgrade

### DIFF
--- a/src/lpm/app.py
+++ b/src/lpm/app.py
@@ -5746,11 +5746,12 @@ def installpkg(
                 )
 
         row = conn.execute(
-            "SELECT version, release FROM installed WHERE name=?",
+            "SELECT version, release, manifest FROM installed WHERE name=?",
             (meta.name,),
         ).fetchone()
         previous_version = row[0] if row else None
         previous_release = row[1] if row else None
+        previous_manifest = json.loads(row[2]) if row and row[2] else []
 
         if txn is not None:
             if register_event:
@@ -5850,6 +5851,17 @@ def installpkg(
                         )
 
                 with operation_phase(privileged=True):
+                    # Atomic package replace for upgrades: remove all previously-owned
+                    # files before materializing the new payload so stale paths and
+                    # conflict prompts do not leak across versions.
+                    if previous_version is not None and previous_manifest:
+                        for old_entry in previous_manifest:
+                            old_path = old_entry.get("path") if isinstance(old_entry, dict) else None
+                            if not old_path:
+                                continue
+                            dest_old = root / str(old_path).lstrip("/")
+                            _replace_path(dest_old)
+
                     # Move into root w/ conflict handling (same as before) ...
                     replace_all = False
                     for e in mani:

--- a/tests/test_installpkg_symlink.py
+++ b/tests/test_installpkg_symlink.py
@@ -259,3 +259,49 @@ def test_installpkg_replace_all_option(tmp_path, monkeypatch):
     assert (root / "etc" / "foo").read_text() == "package foo\n"
     assert (root / "etc" / "bar").read_text() == "package bar\n"
     assert os.stat(root / "etc" / "foo").st_ino != foo_inode_before
+
+
+def test_installpkg_upgrade_is_atomic_replace(tmp_path, monkeypatch):
+    lpm = _import_lpm(tmp_path, monkeypatch)
+    root = tmp_path / "root-atomic-upgrade"
+
+    def build_pkg(version: str, payloads: dict[str, str]) -> Path:
+        staged = tmp_path / f"stage-atomic-{version}"
+        for rel, content in payloads.items():
+            target = staged / rel.lstrip("/")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content)
+        manifest = lpm.collect_manifest(staged)
+        meta = lpm.PkgMeta(name="atomicpkg", version=version, release="1", arch="noarch")
+        (staged / ".lpm-meta.json").write_text(json.dumps(dataclasses.asdict(meta)))
+        (staged / ".lpm-manifest.json").write_text(json.dumps(manifest))
+        out = tmp_path / f"atomicpkg-{version}.zst"
+        with out.open("wb") as f:
+            cctx = lpm.zstd.ZstdCompressor()
+            with cctx.stream_writer(f) as compressor:
+                with tarfile.open(fileobj=compressor, mode="w|") as tf:
+                    for child in staged.iterdir():
+                        tf.add(child, arcname=child.name)
+        shutil.rmtree(staged)
+        return out
+
+    pkg_v1 = build_pkg("1", {"/etc/old.conf": "old
+", "/etc/common.conf": "v1
+"})
+    pkg_v2 = build_pkg("2", {"/etc/new.conf": "new
+", "/etc/common.conf": "v2
+"})
+
+    lpm.installpkg(pkg_v1, root=root, dry_run=False, verify=False, force=False, explicit=True)
+
+    def fail_on_prompt(prompt: str) -> str:
+        raise AssertionError(f"Unexpected conflict prompt: {prompt}")
+
+    monkeypatch.setattr("builtins.input", fail_on_prompt)
+    lpm.installpkg(pkg_v2, root=root, dry_run=False, verify=False, force=False, explicit=True)
+
+    assert not (root / "etc" / "old.conf").exists()
+    assert (root / "etc" / "new.conf").read_text() == "new
+"
+    assert (root / "etc" / "common.conf").read_text() == "v2
+"


### PR DESCRIPTION
## Summary
- switched package upgrade lookup to load previous manifest alongside version metadata
- implemented atomic-replace semantics during upgrades by removing all files previously owned by the package before applying the new manifest
- keeps install conflicts for unrelated files, while preventing stale package-owned files and prompt loops during upgrades
- added regression test covering upgrade behavior to ensure no interactive conflict prompt and full package content replacement

## Files changed
- `src/lpm/app.py`
- `tests/test_installpkg_symlink.py`

## Validation
- Static validation only (no test execution requested in this run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09fdfe52c48327ba652aea1bf4941c)