### PR TITLE
Enforce default-root privilege checks in removepkg

### DIFF
--- a/src/lpm/app.py
+++ b/src/lpm/app.py
@@ -1640,6 +1640,11 @@ def _is_default_root(root: Path) -> bool:
     return any(root_resolved == candidate for candidate in candidates)
 
 
+def _require_privileged_default_root(root: Path, action: str, target: str) -> None:
+    if _is_default_root(root) and os.geteuid() != 0 and not privileges_enabled():
+        die(f"{action} requires root privileges when {target} the default root")
+
+
 SYSTEMD_UNIT_GLOB_PATTERNS = [
     "*.service",
     "*.socket",
@@ -5642,9 +5647,7 @@ def installpkg(
     PROTECTED = load_protected()
 
     root = Path(root)
-    if _is_default_root(root):
-        if os.geteuid() != 0 and not privileges_enabled():
-            die("installpkg requires root privileges when installing to the default root")
+    _require_privileged_default_root(root, "installpkg", "installing to")
 
     is_single_path = isinstance(file, Path)
     files: List[Path] = [Path(file)] if is_single_path else [Path(f) for f in file]
@@ -6040,6 +6043,7 @@ def removepkg(
     PROTECTED = load_protected()
 
     root = Path(root)
+    _require_privileged_default_root(root, "removepkg", "removing from")
     txn = hook_transaction
     owns_txn = False
     if txn is None and not dry_run:

--- a/tests/test_default_root_privileges.py
+++ b/tests/test_default_root_privileges.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lpm import app as lpm
+
+
+def _raise_die(message: str, _code: int = 2):
+    raise RuntimeError(message)
+
+
+def test_removepkg_default_root_requires_privileges(monkeypatch):
+    monkeypatch.setattr(lpm, "_is_default_root", lambda root: True)
+    monkeypatch.setattr(lpm.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(lpm, "privileges_enabled", lambda: False)
+    monkeypatch.setattr(lpm, "die", _raise_die)
+
+    with pytest.raises(RuntimeError, match="removepkg requires root privileges when removing from the default root"):
+        lpm.removepkg("demo", root=Path(lpm.DEFAULT_ROOT))
+
+
+def test_removepkg_non_default_root_skips_privilege_requirement(monkeypatch, tmp_path):
+    monkeypatch.setattr(lpm, "_is_default_root", lambda root: False)
+    monkeypatch.setattr(lpm.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(lpm, "privileges_enabled", lambda: False)
+    monkeypatch.setattr(lpm, "die", _raise_die)
+
+    class _Conn:
+        def execute(self, *_args, **_kwargs):
+            class _Cursor:
+                def fetchone(self):
+                    return None
+
+            return _Cursor()
+
+    monkeypatch.setattr(lpm, "db", lambda: _Conn())
+
+    # Should not fail privilege check for non-default roots.
+    lpm.removepkg("demo", root=tmp_path)


### PR DESCRIPTION
### Motivation
- Ensure mutating operations consistently enforce default-root privilege requirements for both CLI and internal/direct callers to avoid privilege bypass.
- Prevent drift between `installpkg()` and `removepkg()` by centralizing the default-root privilege check in a small helper.

### Description
- Add helper ` _require_privileged_default_root(root: Path, action: str, target: str)` to centralize `_is_default_root(root)`, `os.geteuid() != 0` and `privileges_enabled()` checks and call `die(...)` with an action-specific message in `src/lpm/app.py`.
- Refactor `installpkg()` to call ` _require_privileged_default_root(root, "installpkg", "installing to")` instead of its inline check.
- Invoke ` _require_privileged_default_root(root, "removepkg", "removing from")` immediately after `root = Path(root)` in `removepkg()` so removals from the default root require privileges even when called programmatically.
- Add `tests/test_default_root_privileges.py` which asserts `removepkg(..., root=DEFAULT_ROOT)` fails when unprivileged and that non-default roots skip the privilege requirement.

### Testing
- Ran `pytest -q tests/test_default_root_privileges.py`, which passed (2 tests). 
- Ran `pytest -q tests/test_privileges.py`, which passed (2 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b58cb96bc8327a6884e77edcaa0c6)