### PR TITLE
Add upgradepkg CLI alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ installations at the generated `index.json` files.
 - `lpm remove NAME... [--root PATH] [--dry-run] [--force]`
 - `lpm autoremove [--root PATH] [--dry-run]` – uninstall orphaned dependencies.
 - `lpm upgrade [NAME ...] [--root PATH] [--dry-run] [--no-verify] [--allow-fallback|--no-fallback] [--force]`
+- `lpm upgradepkg [NAME ...] [--root PATH] [--dry-run] [--no-verify] [--allow-fallback|--no-fallback] [--force]` – alias for `upgrade`.
 - `lpm list` – list installed packages.
 - `lpm files NAME` – list files that belong to an installed package.
 - `lpm verify [--root PATH]` – verify that installed files exist.
@@ -339,6 +340,8 @@ contents and runs common maintenance commands based on what it finds:
   – install from local package files.
 - `lpm removepkg NAME... [--root PATH] [--dry-run] [--force]` – remove installed
   packages by name.
+- `lpm upgradepkg [NAME ...] [--root PATH] [--dry-run] [--no-verify] [--allow-fallback|--no-fallback] [--force]`
+  – alias for repository-backed `upgrade`.
 
 #### Symlink manifest digests
 

--- a/docs/TECHNICAL-HOWTO.md
+++ b/docs/TECHNICAL-HOWTO.md
@@ -229,7 +229,10 @@ $ sudo lpm removepkg hello --dry-run
 
 ## 6. Upgrading Systems
 
-### 6.1 `lpm upgrade [NAME ...]`
+### 6.1 `lpm upgrade [NAME ...]` / `lpm upgradepkg [NAME ...]`
+
+`lpm upgradepkg` is a compatibility alias for the repository-backed `lpm upgrade` command.
+Both commands accept the same package-name arguments and upgrade flags.
 
 When invoked without package names, `lpm upgrade` refreshes every installed
 package to the latest available version by generating version constraints such as
@@ -244,6 +247,9 @@ $ sudo lpm upgrade
 
 # Upgrade only openssl and curl, allowing fallback script fetches
 $ sudo lpm upgrade openssl curl --allow-fallback
+
+# Same behavior through the compatibility alias
+$ sudo lpm upgradepkg openssl curl --allow-fallback
 ```
 
 ## 7. Snapshotting and History

--- a/src/lpm/app.py
+++ b/src/lpm/app.py
@@ -3131,9 +3131,7 @@ def do_upgrade(targets: List[str], root: Path, dry: bool, verify: bool, force: b
     # Cleanup services before upgrade
     if upgrades:
         def svc_worker(p: PkgMeta):
-            cur = u.installed.get(p.name)
-            if cur:
-                remove_service_files(p.name, Path(DEFAULT_ROOT), cur.get("manifest"))
+            _cleanup_upgrade_service_files(p, root, u.installed, dry_run=dry)
 
         max_workers = min(8, len(upgrades))
         with ThreadPoolExecutor(max_workers=max_workers) as ex:
@@ -3144,6 +3142,15 @@ def do_upgrade(targets: List[str], root: Path, dry: bool, verify: bool, force: b
 
     do_install(upgrades, root, dry, verify, force=force, explicit=explicit_names)
 
+
+def _cleanup_upgrade_service_files(
+    pkg: PkgMeta, root: Path, installed: Mapping[str, dict], *, dry_run: bool
+) -> None:
+    cur = installed.get(pkg.name)
+    if dry_run or not cur:
+        return
+    with _privileged_default_root_mutation(root, dry_run=dry_run):
+        remove_service_files(pkg.name, root, cur.get("manifest"))
 
 def _compute_needed_set(installed: Dict[str, dict]) -> Set[str]:
     needed: Set[str] = {n for n, m in installed.items() if m.get("explicit")}
@@ -4752,7 +4759,7 @@ def run_lpmbuild(
     return out, duration, phase_count, split_records
 
 # =========================== CLI commands =====================================
-_PRIVILEGED_COMMANDS = {"install", "installpkg", "remove", "upgrade", "rollback"}
+_PRIVILEGED_COMMANDS = {"install", "installpkg", "remove", "upgrade", "upgradepkg", "rollback"}
 def cmd_repolist(_):
     for r in sorted(list_repos(), key=lambda x:x.priority):
         print(f"{r.name:15} {r.url} (prio {r.priority})")
@@ -4961,9 +4968,7 @@ def cmd_upgrade(a):
                 snapshot_id = row[0]
 
             def svc_worker(p: PkgMeta):
-                cur = u.installed.get(p.name)
-                if cur:
-                    remove_service_files(p.name, Path(DEFAULT_ROOT), cur.get("manifest"))
+                _cleanup_upgrade_service_files(p, root, u.installed, dry_run=dry)
 
             max_workers = min(8, len(upgrades))
             with ThreadPoolExecutor(max_workers=max_workers) as ex:
@@ -6401,30 +6406,35 @@ def build_parser()->argparse.ArgumentParser:
     sp.add_argument("--dry-run", action="store_true")
     sp.set_defaults(func=cmd_autoremove)
 
-    sp=sub.add_parser("upgrade", help="Upgrade packages (targets or all)")
-    sp.add_argument("names", nargs="*")
-    sp.add_argument("--root")
-    sp.add_argument("--dry-run", action="store_true")
-    sp.add_argument("--no-verify", action="store_true", help="skip signature verification (DANGEROUS)")
-    sp.add_argument(
-        "--no-delta",
-        action="store_true",
-        help="disable use of delta packages (overrides configuration)",
-    )
-    sp.add_argument(
-        "--allow-fallback",
-        dest="allow_fallback",
-        action="store_true",
-        help="enable GitLab .lpmbuild fallback when the resolver cannot find packages",
-    )
-    sp.add_argument(
-        "--no-fallback",
-        dest="allow_fallback",
-        action="store_false",
-        help="disable GitLab .lpmbuild fallback (overrides configuration)",
-    )
-    sp.add_argument("--force", action="store_true", help="override protected package list for install/upgrade")
-    sp.set_defaults(func=cmd_upgrade, allow_fallback=None)
+    def add_upgrade_subparser(name: str, help_text: str):
+        sp = sub.add_parser(name, help=help_text)
+        sp.add_argument("names", nargs="*")
+        sp.add_argument("--root")
+        sp.add_argument("--dry-run", action="store_true")
+        sp.add_argument("--no-verify", action="store_true", help="skip signature verification (DANGEROUS)")
+        sp.add_argument(
+            "--no-delta",
+            action="store_true",
+            help="disable use of delta packages (overrides configuration)",
+        )
+        sp.add_argument(
+            "--allow-fallback",
+            dest="allow_fallback",
+            action="store_true",
+            help="enable GitLab .lpmbuild fallback when the resolver cannot find packages",
+        )
+        sp.add_argument(
+            "--no-fallback",
+            dest="allow_fallback",
+            action="store_false",
+            help="disable GitLab .lpmbuild fallback (overrides configuration)",
+        )
+        sp.add_argument("--force", action="store_true", help="override protected package list for install/upgrade")
+        sp.set_defaults(func=cmd_upgrade, allow_fallback=None)
+        return sp
+
+    add_upgrade_subparser("upgrade", "Upgrade packages (targets or all)")
+    add_upgrade_subparser("upgradepkg", "Alias for upgrade; upgrade packages (targets or all)")
 
     sp=sub.add_parser("list", help="List installed packages"); sp.set_defaults(func=cmd_list_installed)
     sp=sub.add_parser("files", help="List files installed by package"); sp.add_argument("name"); sp.set_defaults(func=cmd_files)

--- a/tests/test_upgradepkg_cli.py
+++ b/tests/test_upgradepkg_cli.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from lpm import app as lpm
+
+
+def test_upgradepkg_parser_routes_to_existing_upgrade_command():
+    parser = lpm.build_parser()
+
+    args = parser.parse_args(
+        [
+            "upgradepkg",
+            "demo",
+            "--root",
+            "/tmp/lpm-root",
+            "--dry-run",
+            "--no-verify",
+            "--no-delta",
+            "--allow-fallback",
+            "--force",
+        ]
+    )
+
+    assert args.cmd == "upgradepkg"
+    assert args.func is lpm.cmd_upgrade
+    assert args.names == ["demo"]
+    assert args.root == "/tmp/lpm-root"
+    assert args.dry_run is True
+    assert args.no_verify is True
+    assert args.no_delta is True
+    assert args.allow_fallback is True
+    assert args.force is True
+
+
+def test_upgrade_and_upgradepkg_parser_accept_same_relevant_flags():
+    parser = lpm.build_parser()
+    common = ["demo", "--root", "/tmp/lpm-root", "--dry-run", "--no-verify", "--no-delta", "--no-fallback", "--force"]
+
+    upgrade = parser.parse_args(["upgrade", *common])
+    upgradepkg = parser.parse_args(["upgradepkg", *common])
+
+    assert upgradepkg.func is upgrade.func is lpm.cmd_upgrade
+    assert upgradepkg.names == upgrade.names == ["demo"]
+    assert upgradepkg.root == upgrade.root == "/tmp/lpm-root"
+    assert upgradepkg.dry_run == upgrade.dry_run is True
+    assert upgradepkg.no_verify == upgrade.no_verify is True
+    assert upgradepkg.no_delta == upgrade.no_delta is True
+    assert upgradepkg.allow_fallback == upgrade.allow_fallback is False
+    assert upgradepkg.force == upgrade.force is True
+
+
+def test_upgrade_service_cleanup_default_root_uses_privileged_section(monkeypatch):
+    calls = []
+
+    @lpm.contextlib.contextmanager
+    def fake_privileged_section():
+        calls.append("enter")
+        yield
+        calls.append("exit")
+
+    def fake_remove_service_files(name, root, manifest):
+        calls.append(("remove_service_files", name, root, manifest))
+
+    monkeypatch.setattr(lpm, "_is_default_root", lambda root: True)
+    monkeypatch.setattr(lpm, "privileges_enabled", lambda: True)
+    monkeypatch.setattr(lpm, "privileged_section", fake_privileged_section)
+    monkeypatch.setattr(lpm, "remove_service_files", fake_remove_service_files)
+
+    pkg = lpm.PkgMeta(name="demo", version="2.0")
+    installed = {"demo": {"version": "1.0", "manifest": [{"path": "/usr/lib/systemd/system/demo.service"}]}}
+
+    lpm._cleanup_upgrade_service_files(pkg, Path(lpm.DEFAULT_ROOT), installed, dry_run=False)
+
+    assert calls == [
+        "enter",
+        ("remove_service_files", "demo", Path(lpm.DEFAULT_ROOT), installed["demo"]["manifest"]),
+        "exit",
+    ]
+
+
+def test_upgrade_service_cleanup_non_default_root_skips_privileged_section(monkeypatch, tmp_path):
+    calls = []
+
+    @lpm.contextlib.contextmanager
+    def fake_privileged_section():
+        calls.append("enter")
+        yield
+        calls.append("exit")
+
+    def fake_remove_service_files(name, root, manifest):
+        calls.append(("remove_service_files", name, root, manifest))
+
+    monkeypatch.setattr(lpm, "_is_default_root", lambda root: False)
+    monkeypatch.setattr(lpm, "privileges_enabled", lambda: True)
+    monkeypatch.setattr(lpm, "privileged_section", fake_privileged_section)
+    monkeypatch.setattr(lpm, "remove_service_files", fake_remove_service_files)
+
+    pkg = lpm.PkgMeta(name="demo", version="2.0")
+    installed = {"demo": {"version": "1.0", "manifest": ["/etc/init.d/demo"]}}
+
+    lpm._cleanup_upgrade_service_files(pkg, tmp_path, installed, dry_run=False)
+
+    assert calls == [("remove_service_files", "demo", tmp_path, installed["demo"]["manifest"])]
+
+
+def test_upgrade_service_cleanup_dry_run_skips_service_removal(monkeypatch):
+    calls = []
+
+    @lpm.contextlib.contextmanager
+    def fake_privileged_section():
+        calls.append("enter")
+        yield
+        calls.append("exit")
+
+    monkeypatch.setattr(lpm, "_is_default_root", lambda root: True)
+    monkeypatch.setattr(lpm, "privileges_enabled", lambda: True)
+    monkeypatch.setattr(lpm, "privileged_section", fake_privileged_section)
+    monkeypatch.setattr(lpm, "remove_service_files", lambda *_args: calls.append("remove"))
+
+    pkg = lpm.PkgMeta(name="demo", version="2.0")
+    installed = {"demo": {"version": "1.0", "manifest": ["/etc/init.d/demo"]}}
+
+    lpm._cleanup_upgrade_service_files(pkg, Path(lpm.DEFAULT_ROOT), installed, dry_run=True)
+
+    assert calls == []


### PR DESCRIPTION
### Motivation

- Provide a compatibility alias `upgradepkg` that maps to the repository-backed `upgrade` behavior so callers and UI clients can use either name.
- Ensure `upgradepkg` is treated like `upgrade` by the top-level privilege handling so default-root operations enter the privileged phase.
- Centralize upgrade service-file cleanup behind a helper that respects `--dry-run` and uses the existing `_privileged_default_root_mutation()` helper to avoid accidental default-root file mutations.

### Description

- Add a small parser helper `add_upgrade_subparser()` and register both `upgrade` and `upgradepkg` subcommands to route to the same `cmd_upgrade` handler with identical flags.
- Include `upgradepkg` in the `_PRIVILEGED_COMMANDS` set so the CLI privilege wrapper treats it like `upgrade`.
- Introduce `_cleanup_upgrade_service_files(pkg, root, installed, *, dry_run)` which skips work for dry runs and wraps service cleanup in `_privileged_default_root_mutation()`; replace direct calls to `remove_service_files(...)` from upgrade flows with this helper and pass the current `dry` value.
- Update documentation to mention `upgradepkg` as an alias in `README.md` and `docs/TECHNICAL-HOWTO.md` and add parser/privilege-flow tests in `tests/test_upgradepkg_cli.py`.

### Testing

- Ran `pytest -q tests/test_upgradepkg_cli.py tests/test_default_root_privileges.py` and both tests passed (targeted parser and privilege-flow coverage).
- Ran `python -m py_compile src/lpm/app.py` to ensure the modified module compiles and it succeeded.
- Attempted a full test run (`pytest -q`) but collection failed due to an unrelated existing syntax error (unterminated string literal) in `tests/test_installpkg_symlink.py`; this is not introduced by this change and blocks a full suite green run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b8d214f008327bf8d11736b6fc20a)