### PR TITLE
Add `rebuild` CLI: reverse-dependency traversal and deterministic rebuild ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,9 @@ contents and runs common maintenance commands based on what it finds:
 
   ensures that `system-base` advertises `glibc` and `virtual(libc)` while still
   depending on the real `glibc` package.【F:src/lpm/app.py†L3628-L3659】
+- `lpm rebuild NAME [--outdir PATH] [--no-deps] [--install-default y|n] [--force-rebuild]`
+  – rebuild the named installed package and all installed packages that depend
+  on it transitively.
 - `lpm genindex REPO_DIR [--base-url URL] [--arch ARCH]` – generate an
   `index.json` for a directory of packages.
 - `lpm installpkg FILE... [--root PATH] [--dry-run] [--verify] [--force]`
@@ -342,6 +345,15 @@ contents and runs common maintenance commands based on what it finds:
   packages by name.
 - `lpm upgradepkg [NAME ...] [--root PATH] [--dry-run] [--no-verify] [--allow-fallback|--no-fallback] [--force]`
   – alias for repository-backed `upgrade`.
+
+Example rebuild workflow:
+
+```bash
+lpm rebuild libxml2
+```
+
+This rebuilds `libxml2` first, then rebuilds every currently installed package
+that depends on `libxml2` (directly or transitively).
 
 #### Symlink manifest digests
 

--- a/src/lpm/app.py
+++ b/src/lpm/app.py
@@ -5446,6 +5446,106 @@ def cmd_buildpkg(a):
         die(f"Build failed for {a.script}")
 
 
+def _reverse_dependents_from_installed(conn: sqlite3.Connection) -> Dict[str, Set[str]]:
+    rows = list(conn.execute("SELECT name,requires FROM installed ORDER BY name"))
+    installed: Dict[str, Dict[str, object]] = {}
+    for name, requires in rows:
+        req_list: List[str] = []
+        if requires:
+            try:
+                loaded = json.loads(requires)
+                if isinstance(loaded, list):
+                    req_list = [str(item) for item in loaded if item]
+            except Exception:
+                req_list = []
+        installed[name] = {"requires": req_list, "provides": []}
+
+    providers = _installed_provider_map(installed)
+    reverse: Dict[str, Set[str]] = {}
+    for pkg_name, meta in installed.items():
+        for req in meta.get("requires", []) or []:
+            try:
+                expr = parse_dep_expr(req)
+            except Exception:
+                continue
+            matched = _match_dep_expr_against_installed(expr, installed, providers)
+            for dep_name in matched:
+                reverse.setdefault(dep_name, set()).add(pkg_name)
+    return reverse
+
+
+def _resolve_local_lpmbuild_script(pkg_name: str) -> Path:
+    return Path("packages") / pkg_name / f"{pkg_name}.lpmbuild"
+
+
+def cmd_rebuild(a):
+    conn = db()
+    rows = list(conn.execute("SELECT name FROM installed ORDER BY name"))
+    installed_names = {row[0] for row in rows}
+    reverse = _reverse_dependents_from_installed(conn)
+    conn.close()
+
+    if a.name not in installed_names:
+        die(f"Package is not installed: {a.name}")
+
+    levels: Dict[str, int] = {a.name: 0}
+    queue: deque[str] = deque([a.name])
+    while queue:
+        cur = queue.popleft()
+        for dep in sorted(reverse.get(cur, set())):
+            if dep in levels:
+                continue
+            levels[dep] = levels[cur] + 1
+            queue.append(dep)
+
+    closure = sorted(levels.keys())
+    subset_edges: Dict[str, Set[str]] = {
+        pkg: set(sorted(reverse.get(pkg, set()) & set(closure))) for pkg in closure
+    }
+
+    indegree: Dict[str, int] = {pkg: 0 for pkg in closure}
+    for pkg in closure:
+        for child in subset_edges[pkg]:
+            indegree[child] += 1
+    zero = sorted([pkg for pkg, deg in indegree.items() if deg == 0], key=lambda n: (levels[n], n))
+    topo: List[str] = []
+    while zero:
+        node = zero.pop(0)
+        topo.append(node)
+        for child in sorted(subset_edges[node]):
+            indegree[child] -= 1
+            if indegree[child] == 0:
+                zero.append(child)
+                zero.sort(key=lambda n: (levels[n], n))
+    if len(topo) != len(closure):
+        cycle_members = sorted([pkg for pkg, deg in indegree.items() if deg > 0])
+        die("Cycle detected in rebuild dependency graph: " + ", ".join(cycle_members))
+
+    missing: List[Tuple[str, Path]] = []
+    scripts: Dict[str, Path] = {}
+    for pkg in topo:
+        script = _resolve_local_lpmbuild_script(pkg)
+        if not script.exists():
+            missing.append((pkg, script))
+            continue
+        scripts[pkg] = script
+    if missing:
+        formatted = ", ".join([f"{pkg} ({path})" for pkg, path in missing])
+        die(f"Missing .lpmbuild scripts for rebuild targets: {formatted}")
+
+    total = len(topo)
+    for idx, pkg in enumerate(topo, start=1):
+        print(f"[rebuild {idx}/{total}] {pkg}")
+        run_lpmbuild(
+            scripts[pkg],
+            a.outdir,
+            build_deps=not a.no_deps,
+            force_rebuild=a.force_rebuild,
+            prompt_default=a.install_default,
+        )
+    ok(f"Rebuilt packages ({total}): {', '.join(topo)}")
+
+
 def cmd_genindex(a):
     repo_dir = Path(a.repo_dir)
     gen_index(repo_dir, a.base_url, arch_filter=a.arch)
@@ -6509,6 +6609,19 @@ def build_parser()->argparse.ArgumentParser:
     sp.add_argument("--install-default", choices=["y", "n"], help="default answer for install prompt")
     sp.add_argument("--python-pip", metavar="SPEC", help="build a package from a Python distribution fetched via pip")
     sp.set_defaults(func=cmd_buildpkg)
+
+    sp=sub.add_parser("rebuild", help="Rebuild an installed package and all installed reverse dependencies")
+    sp.add_argument("name", help="installed package name to rebuild from")
+    sp.add_argument("--outdir", default=Path.cwd(), type=Path)
+    sp.add_argument("--no-deps", action="store_true", help="do not fetch or build dependencies")
+    sp.add_argument("--install-default", choices=["y", "n"], help="default answer for install prompt")
+    sp.add_argument(
+        "--force-rebuild",
+        action="store_true",
+        default=True,
+        help="rebuild the target package and all reverse dependencies even if already available",
+    )
+    sp.set_defaults(func=cmd_rebuild)
 
     sp=sub.add_parser("genindex", help=f"Generate index.json for a repo directory of {EXT} files")
     sp.add_argument("repo_dir", help=f"directory containing {EXT} files")

--- a/tests/test_rebuild_cli.py
+++ b/tests/test_rebuild_cli.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from lpm import app as lpm
+
+
+def _prepare_db(monkeypatch, tmp_path, rows):
+    db_path = tmp_path / "rebuild.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE installed (name TEXT, requires TEXT)")
+    conn.executemany("INSERT INTO installed(name, requires) VALUES (?, ?)", rows)
+    conn.commit()
+    conn.close()
+    monkeypatch.setattr(lpm, "db", lambda: sqlite3.connect(db_path))
+    return db_path
+
+
+def test_rebuild_computes_transitive_closure_and_order(monkeypatch, tmp_path):
+    _prepare_db(
+        monkeypatch,
+        tmp_path,
+        [
+            ("libxml2", json.dumps([])),
+            ("a", json.dumps(["libxml2"])),
+            ("b", json.dumps(["a"])),
+            ("c", json.dumps(["libxml2"])),
+        ],
+    )
+    for pkg in ("libxml2", "a", "b", "c"):
+        p = tmp_path / "packages" / pkg
+        p.mkdir(parents=True)
+        (p / f"{pkg}.lpmbuild").write_text("#!/bin/sh\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    called = []
+
+    def fake_run(script, outdir, **kwargs):
+        called.append((Path(script), Path(outdir), kwargs))
+        return (tmp_path / "dummy.lpm", 0.0, 1, [])
+
+    monkeypatch.setattr(lpm, "run_lpmbuild", fake_run)
+    args = lpm.build_parser().parse_args(["rebuild", "libxml2", "--outdir", str(tmp_path)])
+    lpm.cmd_rebuild(args)
+
+    order = [item[0].parent.name for item in called]
+    assert order == ["libxml2", "a", "c", "b"]
+
+
+def test_rebuild_missing_script_fails_with_clear_error(monkeypatch, tmp_path):
+    _prepare_db(
+        monkeypatch,
+        tmp_path,
+        [
+            ("libxml2", json.dumps([])),
+            ("a", json.dumps(["libxml2"])),
+        ],
+    )
+    p = tmp_path / "packages" / "libxml2"
+    p.mkdir(parents=True)
+    (p / "libxml2.lpmbuild").write_text("#!/bin/sh\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    args = lpm.build_parser().parse_args(["rebuild", "libxml2"])
+    with pytest.raises(SystemExit):
+        lpm.cmd_rebuild(args)
+
+
+def test_rebuild_parser_wiring_and_upgradepkg_alias_intact():
+    parser = lpm.build_parser()
+
+    rebuild = parser.parse_args(["rebuild", "libxml2", "--no-deps", "--install-default", "n"])
+    assert rebuild.func is lpm.cmd_rebuild
+    assert rebuild.name == "libxml2"
+    assert rebuild.no_deps is True
+    assert rebuild.install_default == "n"
+
+    upgrade_alias = parser.parse_args(["upgradepkg", "demo", "--no-delta"])
+    assert upgrade_alias.func is lpm.cmd_upgrade
+    assert upgrade_alias.names == ["demo"]
+
+
+def test_rebuild_order_is_deterministic(monkeypatch, tmp_path):
+    rows = [
+        ("libxml2", json.dumps([])),
+        ("zeta", json.dumps(["libxml2"])),
+        ("alpha", json.dumps(["libxml2"])),
+    ]
+    _prepare_db(monkeypatch, tmp_path, rows)
+    for pkg in ("libxml2", "alpha", "zeta"):
+        p = tmp_path / "packages" / pkg
+        p.mkdir(parents=True)
+        (p / f"{pkg}.lpmbuild").write_text("#!/bin/sh\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+
+    observed = []
+
+    def fake_run(script, _outdir, **_kwargs):
+        observed.append(Path(script).parent.name)
+        return (tmp_path / "dummy.lpm", 0.0, 1, [])
+
+    monkeypatch.setattr(lpm, "run_lpmbuild", fake_run)
+    args = lpm.build_parser().parse_args(["rebuild", "libxml2"])
+    lpm.cmd_rebuild(args)
+    first = list(observed)
+    observed.clear()
+    lpm.cmd_rebuild(args)
+    second = list(observed)
+
+    assert first == ["libxml2", "alpha", "zeta"]
+    assert second == first


### PR DESCRIPTION
### Motivation
- Provide a way to rebuild an installed package and all installed packages that depend on it transitively using installed metadata (`installed.name`, `installed.requires`).
- Reuse existing dependency parsing/matching logic and the existing `.lpmbuild` build flow so rebuilds behave like `buildpkg` while keeping ordering deterministic and detecting cycles.

### Description
- Added `cmd_rebuild(a)` which computes the transitive reverse-dependent closure from the target package using installed DB rows and reconstructs a reverse-edge graph for traversal.
- Implemented `_reverse_dependents_from_installed(conn)` that loads `installed.requires`, parses dependency expressions with `parse_dep_expr`, and matches them to installed providers via `_match_dep_expr_against_installed` and `_installed_provider_map` to build reverse edges.
- Compute rebuild order so the target is rebuilt first, then dependents by increasing reverse-distance with lexical tie-breaks for determinism, and detect/report cycles with explicit cycle member list.
- Resolve `.lpmbuild` scripts via `packages/<pkg>/<pkg>.lpmbuild` using `_resolve_local_lpmbuild_script` and fail early with an actionable message listing missing package/script paths.
- Reuse `run_lpmbuild(...)` to execute rebuilds with flags aligned to `buildpkg` (`--outdir`, `--no-deps` semantics, `--install-default`, `--force-rebuild`) and emit progress lines like `[rebuild i/N] <pkg>` plus a final summary.
- Wired CLI: added `rebuild` subparser to `build_parser()` with positional `name` and options `--outdir`, `--no-deps`, `--install-default`, `--force-rebuild`, and `set_defaults(func=cmd_rebuild)`.
- Added tests in `tests/test_rebuild_cli.py` covering transitive closure and order, missing script failure, parser wiring (including upgradepkg alias safety), and deterministic ordering across runs.
- Updated `README.md` with `lpm rebuild NAME` usage and example (`lpm rebuild libxml2`).

### Testing
- Ran `pytest -q tests/test_rebuild_cli.py tests/test_upgradepkg_cli.py` and the new tests passed (9 passed total).
- The `rebuild` tests exercise closure computation, missing-script failure, parser wiring, and deterministic ordering and all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bbd1852f88327943a1e233605de4d)