### PR TITLE
Support ARCH any/none compatibility alongside host architecture

### DIFF
--- a/src/lpm/app.py
+++ b/src/lpm/app.py
@@ -664,7 +664,21 @@ def satisfies(ver: str, cons: str) -> bool:
     return True
     
 def arch_compatible(pkg_arch: str, want_arch: str) -> bool:
-    return pkg_arch == "noarch" or pkg_arch == want_arch
+    pkg_norm = (pkg_arch or "").strip().lower()
+    want_norm = (want_arch or "").strip().lower()
+
+    host_arch = (os.uname().machine if hasattr(os, "uname") else "")
+    host_norm = (host_arch or "").strip().lower()
+
+    universal_arches = {"noarch", "any", "none"}
+
+    if pkg_norm in universal_arches:
+        return True
+
+    if want_norm in universal_arches:
+        return pkg_norm == host_norm
+
+    return pkg_norm == want_norm
 
 # =========================== Dep grammar (AND/OR + atoms) =====================
 TOK_RE = re.compile(r"\s*(\(|\)|\|\||\||,|>=|<=|==|=|>|<|~=?|\w[\w\-\._+]*)")

--- a/tests/test_arch_compatibility.py
+++ b/tests/test_arch_compatibility.py
@@ -1,0 +1,18 @@
+import importlib
+
+
+def test_arch_compatible_accepts_any_and_none_as_universal(monkeypatch):
+    lpm = importlib.import_module("lpm.app")
+    monkeypatch.setattr(lpm.os, "uname", lambda: type("U", (), {"machine": "x86_64"})())
+
+    assert lpm.arch_compatible("any", "x86_64")
+    assert lpm.arch_compatible("none", "x86_64")
+
+
+def test_arch_compatible_treats_target_any_and_none_as_host_arch(monkeypatch):
+    lpm = importlib.import_module("lpm.app")
+    monkeypatch.setattr(lpm.os, "uname", lambda: type("U", (), {"machine": "x86_64"})())
+
+    assert lpm.arch_compatible("x86_64", "any")
+    assert lpm.arch_compatible("x86_64", "none")
+    assert not lpm.arch_compatible("aarch64", "any")


### PR DESCRIPTION
## Summary
- updated `arch_compatible()` in `src/lpm/app.py` to treat `any` and `none` as universal package architectures (like `noarch`)
- added handling so when target/wanted arch is `any` or `none`, compatibility resolves against the host architecture (`uname -m`)
- preserved existing direct architecture matching behavior

## Tests
- added `tests/test_arch_compatibility.py` covering:
  - package arch values `any` and `none` installing on host arch
  - target arch values `any` and `none` resolving to host arch
  - rejecting mismatched non-host arch when target is `any`

## Notes
- this change enables packages/scripts that use `ARCH="any"` or `ARCH="none"` to be installed in mixed workflows while still enforcing host-arch safety for non-universal packages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c95844e608327a6a7b3d576f903f0)