### PR TITLE
resolver: honor installed providers for goal/dependency satisfaction

### DIFF
--- a/src/lpm/app.py
+++ b/src/lpm/app.py
@@ -1137,26 +1137,35 @@ def _remove_universe_candidate(u: Universe, meta: PkgMeta) -> None:
         u.providers.pop(token, None)
 
 
-def _first_missing_dependency(u: Universe, expr: DepExpr) -> Optional[DepExpr]:
+def _first_missing_dependency(
+    u: Universe,
+    expr: DepExpr,
+    installed: Mapping[str, dict],
+    installed_providers: Mapping[str, Set[str]],
+) -> Optional[DepExpr]:
     """Return the first dependency sub-expression without providers, if any."""
 
     if expr.kind == "atom":
-        return None if providers_for(u, expr.atom) else expr
+        if providers_for(u, expr.atom):
+            return None
+        if _match_dep_expr_against_installed(expr, installed, installed_providers):
+            return None
+        return expr
 
     if expr.kind == "or":
         parts = flatten_or(expr)
         for part in parts:
-            if _first_missing_dependency(u, part) is None:
+            if _first_missing_dependency(u, part, installed, installed_providers) is None:
                 return None
         for part in parts:
-            missing = _first_missing_dependency(u, part)
+            missing = _first_missing_dependency(u, part, installed, installed_providers)
             if missing is not None:
                 return missing
         return expr
 
     if expr.kind == "and":
         for part in flatten_and(expr):
-            missing = _first_missing_dependency(u, part)
+            missing = _first_missing_dependency(u, part, installed, installed_providers)
             if missing is not None:
                 return missing
         return None
@@ -1177,6 +1186,7 @@ def prune_universe_missing_providers(
 
     disqualified: Dict[Tuple[str, str], str] = {}
     terminal: Dict[str, List[str]] = {}
+    installed_providers = _installed_provider_map(u.installed)
 
     changed = True
     while changed:
@@ -1199,7 +1209,9 @@ def prune_universe_missing_providers(
                         expr = parse_dep_expr(req)
                     except Exception:
                         continue
-                    missing = _first_missing_dependency(u, expr)
+                    missing = _first_missing_dependency(
+                        u, expr, u.installed, installed_providers
+                    )
                     if missing is not None:
                         reason = (
                             f"No provider for dependency '{dep_expr_to_str(missing)}' "
@@ -1257,6 +1269,7 @@ def encode_resolution(
     disqualified, terminal = prune_universe_missing_providers(
         u, include_build_requires
     )
+    installed_providers = _installed_provider_map(u.installed)
 
     cnf = CNF()
     var_of: Dict[Tuple[str,str],int] = {}
@@ -1316,6 +1329,8 @@ def encode_resolution(
                 for part in flatten_and(e):
                     disj = expr_to_cnf_disj(u, part, cnf, var_of)
                     if not disj:
+                        if _match_dep_expr_against_installed(part, u.installed, installed_providers):
+                            continue
                         part_label = dep_expr_to_str(part)
                         raise ResolutionError(
                             f"No provider for dependency '{part_label}' required by {p.name}-{p.version}"
@@ -1324,6 +1339,8 @@ def encode_resolution(
             else:
                 disj = expr_to_cnf_disj(u, e, cnf, var_of)
                 if not disj:
+                    if _match_dep_expr_against_installed(e, u.installed, installed_providers):
+                        continue
                     req_label = dep_expr_to_str(e)
                     raise ResolutionError(
                         f"No provider for dependency '{req_label}' required by {p.name}-{p.version}"
@@ -1370,6 +1387,8 @@ def encode_resolution(
             for part in flatten_and(g):
                 disj = expr_to_cnf_disj(u, part, cnf, var_of)
                 if not disj:
+                    if _match_dep_expr_against_installed(part, u.installed, installed_providers):
+                        continue
                     part_label = dep_expr_to_str(part)
                     reason = None
                     if part.kind == "atom" and part.atom:
@@ -1383,6 +1402,8 @@ def encode_resolution(
         else:
             disj = expr_to_cnf_disj(u, g, cnf, var_of)
             if not disj:
+                if _match_dep_expr_against_installed(g, u.installed, installed_providers):
+                    continue
                 reason = None
                 if g.kind == "atom" and g.atom:
                     reason = _format_reasons(g.atom.name)

--- a/tests/test_solve_installed_satisfaction.py
+++ b/tests/test_solve_installed_satisfaction.py
@@ -1,0 +1,52 @@
+import pytest
+
+from src.lpm.app import PkgMeta, ResolutionError, Universe, register_universe_candidate, solve
+
+
+def _universe(installed=None):
+    return Universe(
+        candidates_by_name={},
+        providers={},
+        installed=installed or {},
+        pins={},
+        holds=set(),
+    )
+
+
+def test_meta_package_dependency_satisfied_by_installed_when_repo_missing_dep():
+    universe = _universe(installed={"dep": {"version": "1.0", "provides": []}})
+    register_universe_candidate(
+        universe,
+        PkgMeta(name="meta", version="1.0", requires=["dep"]),
+    )
+
+    solved = solve(["meta"], universe)
+
+    assert [pkg.name for pkg in solved] == ["meta"]
+
+
+def test_goal_satisfied_by_installed_provides_when_repo_empty():
+    universe = _universe(
+        installed={"provider": {"version": "2.0", "provides": ["virtual-dep"]}}
+    )
+
+    solved = solve(["virtual-dep"], universe)
+
+    assert solved == []
+
+
+def test_version_constrained_goal_satisfied_by_installed_version():
+    universe = _universe(installed={"libfoo": {"version": "3.2", "provides": []}})
+
+    solved = solve(["libfoo>=3.0"], universe)
+
+    assert solved == []
+
+
+def test_no_provider_error_when_not_installed_and_no_repo_candidate():
+    universe = _universe(installed={"other": {"version": "1.0", "provides": []}})
+
+    with pytest.raises(ResolutionError) as excinfo:
+        solve(["missing>=2.0"], universe)
+
+    assert "No provider for goal 'missing>=2.0'" in str(excinfo.value)


### PR DESCRIPTION
### Motivation
- The resolver was disqualifying universe candidates or raising hard "No provider" errors when repository candidates were absent even though equivalent packages (or their `provides`) were already installed locally.
- The intent is to let already-installed packages participate in provider lookups so goals and package requirements can be satisfied by local state without changing how new install candidates are selected from repos.

### Description
- Thread installed provider information into dependency pruning by adding `installed_providers = _installed_provider_map(u.installed)` and updating `_first_missing_dependency(...)` to accept `installed` and `installed_providers` and consult `_match_dep_expr_against_installed(...)`.
- Reuse `_installed_provider_map(...)` and `_match_dep_expr_against_installed(...)` in `encode_resolution(...)` to short-circuit `No provider` checks for both package requirements and goal expressions when an installed package (or its `provides`) satisfies the expression, including version constraints.
- Preserve existing behavior when installed packages do not satisfy a dependency by keeping repo-based candidate selection and only bypassing the hard error when local installs match.
- Add focused regression tests in `tests/test_solve_installed_satisfaction.py` covering meta-package deps satisfied by installed packages, provider satisfaction via `provides`, version-constrained satisfaction by installed versions, and the unchanged error path when nothing satisfies a goal.

### Testing
- Ran `pytest -q tests/test_solve_installed_satisfaction.py tests/test_resolver_errors.py tests/test_resolution_error.py`, and the suite completed with `7 passed`.
- Existing resolver error tests continue to pass, verifying unchanged behavior when neither installed packages nor repo candidates satisfy a goal.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ddd4fb27c83279a44d1757b575883)