### PR TITLE
hooks: handle glib schema override files

### DIFF
--- a/usr/libexec/lpm/hooks/glib-compile-schemas
+++ b/usr/libexec/lpm/hooks/glib-compile-schemas
@@ -17,7 +17,7 @@ def _iter_schema_dirs(root: Path, targets: Iterable[str]) -> List[Path]:
         if not rel:
             continue
         path = root / rel
-        if path.suffix.lower() != ".xml":
+        if path.suffix.lower() not in {".xml", ".override"}:
             continue
         parent = path.parent
         if parent in seen or not parent.is_dir():

--- a/usr/share/liblpm/hooks/glib-compile-schemas.hook
+++ b/usr/share/liblpm/hooks/glib-compile-schemas.hook
@@ -4,6 +4,7 @@ Operation = Install
 Operation = Upgrade
 Operation = Remove
 Target = usr/share/glib-2.0/schemas/*.xml
+Target = usr/share/glib-2.0/schemas/*.override
 
 [Action]
 When = PostTransaction


### PR DESCRIPTION
### Motivation
- Ensure LPM's glib schema hook mirrors Arch's behavior by triggering recompilation when either schema XML files or schema `.override` files change.

### Description
- Add `Target = usr/share/glib-2.0/schemas/*.override` to `usr/share/liblpm/hooks/glib-compile-schemas.hook` so override files are watched.
- Update `usr/libexec/lpm/hooks/glib-compile-schemas` to treat files with suffixes `".xml"` or `".override"` as schema targets in `_iter_schema_dirs`.
- The hook still invokes `glib-compile-schemas` with `--targetdir` for each affected schema directory.

### Testing
- Ran `pytest -q tests/test_hooks.py` which produced `19 passed, 1 failed`.
- The failing test was `test_transaction_manager_failure_handling` and is an existing expectation mismatch unrelated to the glib schema hook changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ef9893a58832790e189f2307ea100)