### PR TITLE
Support versioned dependency maps in lpmbuild metadata

### DIFF
--- a/src/lpm/app.py
+++ b/src/lpm/app.py
@@ -3348,6 +3348,11 @@ def _capture_lpmbuild_metadata(
         '      for x in "${ref[@]}"; do printf "%s\\0" "$x"; done',
         '      printf "\n"',
         '      return',
+        '    elif declare -p "$n" 2>/dev/null | grep -q "declare -A"; then',
+        '      declare -n ref="$n"',
+        '      for k in "${!ref[@]}"; do printf "%s=>%s\\0" "$k" "${ref[$k]}"; done',
+        '      printf "\n"',
+        '      return',
         '    elif [[ ${!n+x} == x ]]; then',
         '      declare -n ref="$n"',
         '      if [[ -n "${ref}" ]]; then printf "%s\\0" "${ref}"; fi',
@@ -3427,6 +3432,21 @@ def _capture_lpmbuild_metadata(
 
     i = 0
     n = len(data)
+
+    def _normalize_dep_entry(entry: str) -> str:
+        if "=>" not in entry:
+            return entry
+        name, version = entry.split("=>", 1)
+        dep_name = name.strip()
+        dep_version = version.strip()
+        if not dep_name:
+            return entry
+        if not dep_version:
+            return dep_name
+        if dep_version.startswith(("<=", ">=", "==", "=", "<", ">", "~", "~=")):
+            return f"{dep_name}{dep_version}"
+        return f"{dep_name}>={dep_version}"
+
     while i < n:
         if data.startswith(b"__SCALAR__ ", i):
             j = data.find(b"\n", i)
@@ -3447,6 +3467,8 @@ def _capture_lpmbuild_metadata(
                 for chunk in data[start:end].split(b"\0")
                 if chunk
             ]
+            if canonical in {"REQUIRES", "BUILD_REQUIRES"}:
+                elements = [_normalize_dep_entry(element) for element in elements]
             arrays.setdefault(canonical, []).extend(elements)
             i = end + 1
         elif data.startswith(b"__MAP__ ", i):

--- a/tests/test_run_lpmbuild_dependencies.py
+++ b/tests/test_run_lpmbuild_dependencies.py
@@ -683,6 +683,58 @@ def test_run_lpmbuild_collects_dependency_arrays(tmp_path, monkeypatch):
     assert meta.suggests == ["valgrind"]
 
 
+def test_run_lpmbuild_supports_versioned_dependency_maps(tmp_path, monkeypatch):
+    script = tmp_path / "versioned.lpmbuild"
+    script.write_text(
+        textwrap.dedent(
+            """
+            NAME=toolchain
+            VERSION=1
+            RELEASE=2
+            ARCH=noarch
+            declare -A REQUIRES=(
+              [glibc]='2.43'
+              [libffi]='3.52'
+              [zlib]=''
+              [pcre2]='>=10.47'
+              [libmount]=''
+            )
+            prepare() { :; }
+            build() { :; }
+            staging() {
+                mkdir -p "$pkgdir"
+                echo hi > "$pkgdir/hi"
+            }
+            """
+        )
+    )
+
+    monkeypatch.setenv("LPM_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setattr(lpm, "sandboxed_run", lambda *args, **kwargs: None)
+    monkeypatch.setattr(lpm, "generate_install_script", lambda stagedir: "echo hi")
+
+    captured = {}
+
+    def fake_build_package(stagedir, meta, out, sign=True):
+        captured["meta"] = meta
+        out.write_text("pkg")
+
+    monkeypatch.setattr(lpm, "build_package", fake_build_package)
+
+    out_path, _, _, _ = lpm.run_lpmbuild(
+        script,
+        outdir=tmp_path,
+        prompt_install=False,
+        build_deps=False,
+    )
+
+    assert out_path.exists()
+    meta = captured["meta"]
+    assert sorted(meta.requires) == sorted(
+        ["glibc>=2.43", "libffi>=3.52", "zlib", "pcre2>=10.47", "libmount"]
+    )
+
+
 def test_run_lpmbuild_caches_installed_lookup(tmp_path, monkeypatch):
     deps = [f"dep{i}" for i in range(5)]
     script = tmp_path / "foo.lpmbuild"
@@ -769,4 +821,3 @@ def test_run_lpmbuild_dependency_scan_benchmark(tmp_path, monkeypatch):
     assert calls["db"] == calls["db_installed"] == calls["close"] == iterations
     assert iterations < len(deps)
     assert sum(durations) >= 0
-


### PR DESCRIPTION
### Motivation
- Allow `.lpmbuild` scripts to declare versioned dependencies as associative maps (e.g. `declare -A REQUIRES=( [glibc]='2.43' )`) so versioned requirements configured that way are usable by the resolver and build pipeline.

### Description
- Extend the metadata capture shell wrapper in `_capture_lpmbuild_metadata` so `_emit_array` emits `key=>value` entries when encountering `declare -A` associative arrays. 
- Add `_normalize_dep_entry` which converts map-style entries like `name=>2.43` into a dependency expression (`name>=2.43`) while preserving explicit operators such as `>=10.47` and treating empty values as plain package names. 
- Apply normalization to `REQUIRES` and `BUILD_REQUIRES` array payloads so existing dependency parsing/resolve logic can consume the generated versioned expressions without further changes. 
- Add `test_run_lpmbuild_supports_versioned_dependency_maps` to `tests/test_run_lpmbuild_dependencies.py` to cover map-style `REQUIRES` declarations and verify normalization output.

### Testing
- Ran `pytest -q tests/test_run_lpmbuild_dependencies.py -k "collects_dependency_arrays or versioned_dependency_maps"` and the selected tests passed (`2 passed, 11 deselected`).
- The change was committed with the message `Support versioned dependency maps in lpmbuild metadata` and updates include `src/lpm/app.py` and `tests/test_run_lpmbuild_dependencies.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f00a5ed8c8327903e3b8549aa8930)