### PR TITLE
Add smart SAT unsat diagnostics for conflicts and dependency cycles

### DIFF
--- a/src/lpm/app.py
+++ b/src/lpm/app.py
@@ -1426,6 +1426,81 @@ def encode_resolution(
 def solve(
     goals: List[str], universe: Universe, *, include_build_requires: bool = False
 ) -> List[PkgMeta]:
+    def _summarize_unsat_packages(packages: List[str]) -> str:
+        pkg_set = set(packages)
+        conflicts: Set[Tuple[str, str]] = set()
+        dep_edges: Dict[str, Set[str]] = {name: set() for name in pkg_set}
+
+        for name in pkg_set:
+            for candidate in universe.candidates_by_name.get(name, []):
+                # detect conflicts/obsoletes among the unsat core packages
+                for expr_text in list(candidate.conflicts) + list(candidate.obsoletes):
+                    if not expr_text:
+                        continue
+                    try:
+                        expr = parse_dep_expr(expr_text)
+                    except Exception:
+                        continue
+                    parts = flatten_and(expr) if expr.kind == "and" else [expr]
+                    for part in parts:
+                        if part.kind != "atom" or not part.atom:
+                            continue
+                        for provider in providers_for(universe, part.atom):
+                            if provider.name in pkg_set and provider.name != name:
+                                pair = tuple(sorted((name, provider.name)))
+                                conflicts.add(pair)
+
+                # build dependency graph over the unsat packages
+                for req in _iter_requires(candidate, include_build_requires):
+                    if not req:
+                        continue
+                    try:
+                        expr = parse_dep_expr(req)
+                    except Exception:
+                        continue
+                    parts = flatten_and(expr) if expr.kind == "and" else [expr]
+                    for part in parts:
+                        if part.kind != "atom" or not part.atom:
+                            continue
+                        for provider in providers_for(universe, part.atom):
+                            if provider.name in pkg_set and provider.name != name:
+                                dep_edges[name].add(provider.name)
+
+        cycle: List[str] = []
+        visited: Set[str] = set()
+        stack: List[str] = []
+        onstack: Set[str] = set()
+
+        def dfs(node: str) -> bool:
+            visited.add(node)
+            stack.append(node)
+            onstack.add(node)
+            for nxt in dep_edges.get(node, ()):
+                if nxt not in visited:
+                    if dfs(nxt):
+                        return True
+                elif nxt in onstack:
+                    idx = stack.index(nxt)
+                    cycle.extend(stack[idx:] + [nxt])
+                    return True
+            stack.pop()
+            onstack.discard(node)
+            return False
+
+        for node in sorted(pkg_set):
+            if node not in visited and dfs(node):
+                break
+
+        details: List[str] = []
+        if conflicts:
+            pairs = [f"{a} ↔ {b}" for a, b in sorted(conflicts)]
+            details.append("conflicts: " + ", ".join(pairs))
+        if cycle:
+            details.append("dependency cycle: " + " -> ".join(cycle))
+        if not details:
+            return ""
+        return " (" + "; ".join(details) + ")"
+
     goal_exprs = [parse_dep_expr(s) for s in goals]
     (
         cnf,
@@ -1462,8 +1537,9 @@ def solve(
     inv: Dict[int,Tuple[str,str]] = {v:k for k,v in var_of.items()}
     if not res.sat:
         names = sorted({inv.get(abs(l))[0] for l in (res.unsat_core or []) if abs(l) in inv})
+        details = _summarize_unsat_packages(names)
         raise ResolutionError(
-            "Unsatisfiable dependency set involving: " + ", ".join(names)
+            "Unsatisfiable dependency set involving: " + ", ".join(names) + details
         )
     chosen: Dict[str,PkgMeta] = {}
     for vid,val in res.assign.items():

--- a/tests/test_resolver_errors.py
+++ b/tests/test_resolver_errors.py
@@ -55,3 +55,47 @@ def test_build_requires_checked_when_enabled():
 
     solved = solve(["builder"], clean_universe)
     assert [p.name for p in solved] == ["builder"]
+
+
+def test_unsat_conflict_details_include_conflicting_pair():
+    universe = Universe(
+        candidates_by_name={},
+        providers={},
+        installed={},
+        pins={},
+        holds=set(),
+    )
+    a = PkgMeta(name="A", version="1.0", conflicts=["B"])
+    b = PkgMeta(name="B", version="1.0")
+    register_universe_candidate(universe, a)
+    register_universe_candidate(universe, b)
+
+    with pytest.raises(ResolutionError) as excinfo:
+        solve(["A", "B"], universe)
+
+    msg = str(excinfo.value)
+    assert "Unsatisfiable dependency set involving: A, B" in msg
+    assert "conflicts: A ↔ B" in msg
+
+
+def test_unsat_details_include_dependency_cycle():
+    universe = Universe(
+        candidates_by_name={},
+        providers={},
+        installed={},
+        pins={},
+        holds=set(),
+    )
+    a = PkgMeta(name="A", version="1.0", requires=["B"])
+    b = PkgMeta(name="B", version="1.0", requires=["C"])
+    c = PkgMeta(name="C", version="1.0", requires=["A"], conflicts=["B"])
+    register_universe_candidate(universe, a)
+    register_universe_candidate(universe, b)
+    register_universe_candidate(universe, c)
+
+    with pytest.raises(ResolutionError) as excinfo:
+        solve(["A", "B"], universe)
+
+    msg = str(excinfo.value)
+    assert "Unsatisfiable dependency set involving" in msg
+    assert "dependency cycle:" in msg


### PR DESCRIPTION
## Summary
- Extended resolver unsat handling to produce smarter diagnostics from UNSAT core packages.
- Added conflict-pair detection across core packages by inspecting conflicts/obsoletes clauses.
- Added dependency-cycle detection (DFS over core package dependency edges) and surfaced detected cycle path in error text.
- Appended these details to `ResolutionError` on unsatisfiable solve results.

## Details
- In `solve()` (`src/lpm/app.py`), introduced `_summarize_unsat_packages()`:
  - Builds a package subset graph from core names.
  - Collects conflicting package pairs (`A ↔ B`) by resolving conflict expressions to providers.
  - Collects dependency edges from `requires`/`build_requires` (when enabled).
  - Detects one cycle path if present.
  - Returns formatted diagnostics string.
- Updated unsat raise path to include this detail string.

## Tests
- Added tests in `tests/test_resolver_errors.py`:
  - `test_unsat_conflict_details_include_conflicting_pair`
  - `test_unsat_details_include_dependency_cycle`
- These assert the new error message includes conflict/cycle context for representative unsat cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f047153908327a12e47f91a0dae40)