### PR TITLE
Add rebuild preflight conflict validation and tests

### DIFF
--- a/src/lpm/app.py
+++ b/src/lpm/app.py
@@ -5713,8 +5713,30 @@ def _order_rebuild_targets(
 
 def cmd_rebuild(a):
     conn = db()
-    rows = list(conn.execute("SELECT name FROM installed ORDER BY name"))
-    installed_names = {row[0] for row in rows}
+    rows = list(
+        conn.execute(
+            "SELECT name,version,conflicts,obsoletes,provides FROM installed ORDER BY name"
+        )
+    )
+    installed_meta: Dict[str, dict] = {}
+    for name, version, conflicts_raw, obsoletes_raw, provides_raw in rows:
+        def _decode_list(raw: Any) -> List[str]:
+            if isinstance(raw, str):
+                try:
+                    parsed = json.loads(raw)
+                except Exception:
+                    return [raw] if raw else []
+                if isinstance(parsed, list):
+                    return [str(item) for item in parsed if item]
+            return []
+
+        installed_meta[name] = {
+            "version": version or "",
+            "conflicts": _decode_list(conflicts_raw),
+            "obsoletes": _decode_list(obsoletes_raw),
+            "provides": _decode_list(provides_raw),
+        }
+    installed_names = set(installed_meta.keys())
     reverse = _reverse_dependents_from_installed(conn)
     conn.close()
 
@@ -5731,6 +5753,29 @@ def cmd_rebuild(a):
     if cycle_groups and a.cycle_policy == "group":
         for group in cycle_groups:
             print(f"[rebuild cycle-group] {', '.join(group)}")
+
+    providers = _installed_provider_map(installed_meta)
+    conflict_pairs: Set[Tuple[str, str]] = set()
+    for pkg in topo:
+        meta = installed_meta.get(pkg, {})
+        for raw in (meta.get("conflicts", []) or []) + (meta.get("obsoletes", []) or []):
+            if not raw:
+                continue
+            try:
+                expr = parse_dep_expr(raw)
+            except Exception:
+                warn(f"Invalid rebuild conflict expression in {pkg}: {raw}")
+                continue
+            for matched_pkg in _match_dep_expr_against_installed(expr, installed_meta, providers):
+                if matched_pkg not in topo or matched_pkg == pkg:
+                    continue
+                conflict_pairs.add(tuple(sorted((pkg, matched_pkg))))
+    if conflict_pairs and a.conflict_policy == "fail":
+        formatted = ", ".join(f"{left} <-> {right}" for left, right in sorted(conflict_pairs))
+        die(f"Rebuild preflight failed: conflicting targets detected: {formatted}")
+    if conflict_pairs and a.conflict_policy == "skip":
+        for left, right in sorted(conflict_pairs):
+            warn(f"Skipping conflicting pair due to --conflict-policy=skip: {left} <-> {right}")
 
     missing: List[Tuple[str, Path]] = []
     scripts: Dict[str, Path] = {}
@@ -6837,6 +6882,12 @@ def build_parser()->argparse.ArgumentParser:
         action="store_true",
         default=True,
         help="rebuild the target package and all reverse dependencies even if already available",
+    )
+    sp.add_argument(
+        "--conflict-policy",
+        choices=["fail", "skip"],
+        default="fail",
+        help="how to handle rebuild target conflicts detected during preflight (default: fail)",
     )
     sp.set_defaults(func=cmd_rebuild)
 

--- a/tests/test_rebuild_cli.py
+++ b/tests/test_rebuild_cli.py
@@ -12,8 +12,20 @@ from lpm import app as lpm
 def _prepare_db(monkeypatch, tmp_path, rows):
     db_path = tmp_path / "rebuild.db"
     conn = sqlite3.connect(db_path)
-    conn.execute("CREATE TABLE installed (name TEXT, requires TEXT)")
-    conn.executemany("INSERT INTO installed(name, requires) VALUES (?, ?)", rows)
+    conn.execute(
+        "CREATE TABLE installed (name TEXT, version TEXT, requires TEXT, conflicts TEXT, obsoletes TEXT, provides TEXT)"
+    )
+    normalized = []
+    for row in rows:
+        if len(row) == 2:
+            name, requires = row
+            normalized.append((name, "1.0.0", requires, json.dumps([]), json.dumps([]), json.dumps([name])))
+        else:
+            normalized.append(row)
+    conn.executemany(
+        "INSERT INTO installed(name, version, requires, conflicts, obsoletes, provides) VALUES (?, ?, ?, ?, ?, ?)",
+        normalized,
+    )
     conn.commit()
     conn.close()
     monkeypatch.setattr(lpm, "db", lambda: sqlite3.connect(db_path))
@@ -79,6 +91,7 @@ def test_rebuild_parser_wiring_and_upgradepkg_alias_intact():
     assert rebuild.no_deps is True
     assert rebuild.install_default == "n"
     assert rebuild.cycle_policy == "fail"
+    assert rebuild.conflict_policy == "fail"
 
     upgrade_alias = parser.parse_args(["upgradepkg", "demo", "--no-delta"])
     assert upgrade_alias.func is lpm.cmd_upgrade
@@ -184,3 +197,45 @@ def test_rebuild_cycle_policy_defaults_to_fail(monkeypatch, tmp_path):
     args = lpm.build_parser().parse_args(["rebuild", "base"])
     with pytest.raises(SystemExit):
         lpm.cmd_rebuild(args)
+
+
+def test_rebuild_preflight_conflict_pair_fails(monkeypatch, tmp_path, capsys):
+    _prepare_db(
+        monkeypatch,
+        tmp_path,
+        [
+            ("base", "1.0.0", json.dumps([]), json.dumps([]), json.dumps([]), json.dumps(["base"])),
+            ("alpha", "1.0.0", json.dumps(["base"]), json.dumps(["beta"]), json.dumps([]), json.dumps(["alpha"])),
+            ("beta", "1.0.0", json.dumps(["alpha"]), json.dumps([]), json.dumps([]), json.dumps(["beta"])),
+        ],
+    )
+    for pkg in ("base", "alpha", "beta"):
+        p = tmp_path / "packages" / pkg
+        p.mkdir(parents=True)
+        (p / f"{pkg}.lpmbuild").write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    args = lpm.build_parser().parse_args(["rebuild", "base"])
+    with pytest.raises(SystemExit):
+        lpm.cmd_rebuild(args)
+    assert "alpha <-> beta" in capsys.readouterr().err
+
+
+def test_rebuild_preflight_conflict_expression_matches_provider(monkeypatch, tmp_path, capsys):
+    _prepare_db(
+        monkeypatch,
+        tmp_path,
+        [
+            ("base", "1.0.0", json.dumps([]), json.dumps([]), json.dumps([]), json.dumps(["base"])),
+            ("provider", "2.0.0", json.dumps(["base"]), json.dumps([]), json.dumps([]), json.dumps(["provider", "virtual-lib=2.0.0"])),
+            ("consumer", "1.0.0", json.dumps(["provider"]), json.dumps(["virtual-lib>=1.5"]), json.dumps([]), json.dumps(["consumer"])),
+        ],
+    )
+    for pkg in ("base", "provider", "consumer"):
+        p = tmp_path / "packages" / pkg
+        p.mkdir(parents=True)
+        (p / f"{pkg}.lpmbuild").write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    args = lpm.build_parser().parse_args(["rebuild", "base"])
+    with pytest.raises(SystemExit):
+        lpm.cmd_rebuild(args)
+    assert "consumer <-> provider" in capsys.readouterr().err


### PR DESCRIPTION
### Motivation
- Prevent starting rebuilds when the computed rebuild target set contains pairwise conflicts or obsoletes, including expression-based conflicts involving virtual `provides`.
- Surface a deterministic, concise error before any build work begins so users can resolve package conflicts first.

### Description
- Added a preflight validator in `cmd_rebuild` that runs after `topo` is computed and before script lookup/execution and loads installed metadata (`name`, `version`, `conflicts`, `obsoletes`, `provides`).
- Reused existing helpers `parse_dep_expr`, `_match_dep_expr_against_installed`, and `_installed_provider_map` to parse expressions and detect provider-backed matches and then collect deterministic pairwise conflict pairs within the `topo` set.
- When conflicts are found the command aborts with a deterministic message listing `packageA <-> packageB` pairs, and a new CLI switch `--conflict-policy` (`fail`|`skip`, default `fail`) was added to allow skipping (logs warnings) instead of failing.
- Defensive parsing for stored list fields was added so JSON-encoded or raw strings in the DB are handled when loading `conflicts`, `obsoletes`, and `provides`.

### Testing
- Added tests in `tests/test_rebuild_cli.py` covering a conflicting pair preflight (`test_rebuild_preflight_conflict_pair_fails`) and expression-based/provider conflict (`test_rebuild_preflight_conflict_expression_matches_provider`), while preserving deterministic-order and existing cycle-policy tests.
- Ran `pytest -q tests/test_rebuild_cli.py` and all tests passed (9 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f06d1e4a88327b6eaa7e93374b858)