### PR TITLE
Harden hook execution for non-root target/bootstrap flows

### DIFF
--- a/src/lpm/hooks/__init__.py
+++ b/src/lpm/hooks/__init__.py
@@ -408,7 +408,7 @@ class HookTransactionManager:
                 "LPM_HOOK_NAME": hook.name,
                 "LPM_HOOK_PATH": str(hook.path),
                 "LPM_HOOK_WHEN": action.when,
-                "LPM_ROOT": str(self.root),
+                "LPM_ROOT": str(self.root.resolve()),
             }
         )
         if action.needs_targets:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -385,6 +385,42 @@ def test_update_grub_hook_runs_mkconfig_for_install(
     assert all(not call.startswith("update-grub") for call in calls)
 
 
+def test_update_grub_hook_uses_target_paths_for_bootstrap(tmp_path, monkeypatch, system_hook_dir):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log = tmp_path / "grub-target.log"
+    for name in ("grub-install", "grub-mkconfig", "update-grub", "mount"):
+        script = bin_dir / name
+        script.write_text(f"#!/bin/sh\necho {name} \"$@\" >> {log}\n", encoding="utf-8")
+        script.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+
+    root = tmp_path / "root"
+    (root / "etc").mkdir(parents=True, exist_ok=True)
+    (root / "etc" / "fstab").write_text("UUID=FAKE /boot/efi vfat defaults 0 1\n", encoding="utf-8")
+
+    hooks = load_hooks([system_hook_dir])
+    txn = HookTransactionManager(hooks=hooks, root=root)
+    txn.add_package_event(
+        name="grub2",
+        operation="Install",
+        version="2.06",
+        release="1",
+        paths=["/usr/share/grub"],
+    )
+    txn.ensure_pre_transaction()
+    txn.run_post_transaction()
+
+    calls = log.read_text(encoding="utf-8").splitlines()
+    assert all(not call.startswith("mount ") for call in calls)
+    assert any(f"--efi-directory {root / 'boot/efi'}" in call for call in calls)
+    assert any(f"--boot-directory {root / 'boot'}" in call for call in calls)
+    assert any("--no-nvram" in call and "--removable" in call for call in calls)
+    assert any(f"grub-mkconfig -o {root / 'boot/grub/grub.cfg'}" in call for call in calls)
+    assert all(not call.startswith("update-grub") for call in calls)
+    assert all(" /boot/" not in f" {call} " for call in calls)
+
+
 def test_systemd_daemon_reload_runs_only_for_real_root(
     tmp_path, monkeypatch, system_hook_dir
 ):
@@ -454,8 +490,9 @@ def test_kernel_install_hook(tmp_path, monkeypatch):
     mkinitcpio_call = f"mkinitcpio -r {root} -k {version} -g {root / 'boot' / f'initrd-{version}.img'}"
     assert depmod_call in calls
     assert mkinitcpio_call in calls
-    assert "bootctl update" in calls
-    assert "grub-mkconfig -o /boot/grub/grub.cfg" in calls
+    assert "bootctl update" not in calls
+    assert f"grub-mkconfig -o {root / 'boot/grub/grub.cfg'}" in calls
+    assert all(" /boot/" not in f" {call} " for call in calls)
 
 
 def test_kernel_install_transaction_hook(tmp_path, monkeypatch, system_hook_dir):
@@ -489,8 +526,9 @@ def test_kernel_install_transaction_hook(tmp_path, monkeypatch, system_hook_dir)
     mkinitcpio_call = f"mkinitcpio -r {root} -k {version} -g {root / 'boot' / f'initrd-{version}.img'}"
     assert depmod_call in calls
     assert mkinitcpio_call in calls
-    assert "bootctl update" in calls
-    assert "grub-mkconfig -o /boot/grub/grub.cfg" in calls
+    assert "bootctl update" not in calls
+    assert f"grub-mkconfig -o {root / 'boot/grub/grub.cfg'}" in calls
+    assert all(" /boot/" not in f" {call} " for call in calls)
 
 
 def test_kernel_modules_install_transaction_hook(tmp_path, monkeypatch, system_hook_dir):
@@ -524,8 +562,9 @@ def test_kernel_modules_install_transaction_hook(tmp_path, monkeypatch, system_h
     mkinitcpio_call = f"mkinitcpio -r {root} -k {version} -g {root / 'boot' / f'initrd-{version}.img'}"
     assert depmod_call in calls
     assert mkinitcpio_call in calls
-    assert "bootctl update" in calls
-    assert "grub-mkconfig -o /boot/grub/grub.cfg" in calls
+    assert "bootctl update" not in calls
+    assert f"grub-mkconfig -o {root / 'boot/grub/grub.cfg'}" in calls
+    assert all(" /boot/" not in f" {call} " for call in calls)
 
 
 def test_kernel_install_hook_makes_existing_initrd_writable(tmp_path, monkeypatch):

--- a/usr/libexec/lpm/hooks/kernel-install
+++ b/usr/libexec/lpm/hooks/kernel-install
@@ -90,7 +90,7 @@ def main(argv: List[str] | None = None) -> None:
     if argv is None:
         argv = sys.argv[1:]
 
-    root = Path(os.environ.get("LPM_ROOT", "/"))
+    root = Path(os.environ.get("LPM_ROOT", "/")).resolve()
     _log(f"Using root: {root}")
     versions = _collect_versions(argv)
     if versions:
@@ -116,13 +116,17 @@ def main(argv: List[str] | None = None) -> None:
         _log("No actions to perform; exiting")
         return
 
-    if shutil.which("bootctl"):
+    if root == Path("/") and shutil.which("bootctl"):
         _run_command(["bootctl", "update"], check=False)
+    elif root != Path("/"):
+        _log("Skipping systemd-boot update in target root to avoid host EFI variable changes")
     else:
         _log("Skipping systemd-boot update; bootctl not found")
 
+    grub_cfg = root / "boot/grub/grub.cfg"
     if shutil.which("grub-mkconfig"):
-        _run_command(["grub-mkconfig", "-o", "/boot/grub/grub.cfg"], check=False)
+        grub_cfg.parent.mkdir(parents=True, exist_ok=True)
+        _run_command(["grub-mkconfig", "-o", str(grub_cfg)], check=False)
     else:
         _log("Skipping GRUB configuration update; grub-mkconfig not found")
 

--- a/usr/libexec/lpm/hooks/update-grub
+++ b/usr/libexec/lpm/hooks/update-grub
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
-ROOT = Path(os.environ.get("LPM_ROOT", "/"))
+ROOT = Path(os.environ.get("LPM_ROOT", "/")).resolve()
 
 
 @dataclass
@@ -34,9 +34,9 @@ def _desired_mount_point() -> str:
 
 def _efi_directory() -> Path:
     mount_point = Path(_desired_mount_point())
-    if mount_point.is_absolute():
+    if mount_point.is_absolute() and ROOT == Path("/"):
         return mount_point
-    return ROOT / mount_point
+    return ROOT / mount_point.relative_to("/") if mount_point.is_absolute() else ROOT / mount_point
 
 
 def _iter_fstab_entries() -> list[FstabEntry]:
@@ -71,6 +71,9 @@ def _find_efi_fstab_entry() -> FstabEntry | None:
 
 
 def _ensure_efi_mounted(efi_dir: Path) -> bool:
+    if ROOT != Path("/"):
+        efi_dir.mkdir(parents=True, exist_ok=True)
+        return True
     if os.path.ismount(str(efi_dir)):
         return True
 
@@ -95,20 +98,16 @@ def _run_grub_install(efi_dir: Path) -> None:
     if not _ensure_efi_mounted(efi_dir):
         return
 
-    subprocess.run(
-        [
-            grub_install,
-            "--target=x86_64-efi",
-            "--efi-directory",
-            str(efi_dir),
-            "--bootloader-id=Lumin",
-        ],
-        check=False,
-    )
-
-
-def _is_real_root() -> bool:
-    return ROOT == Path("/")
+    args = [
+        grub_install,
+        "--target=x86_64-efi",
+        "--efi-directory",
+        str(efi_dir),
+        "--bootloader-id=Lumin",
+    ]
+    if ROOT != Path("/"):
+        args.extend(["--boot-directory", str(ROOT / "boot"), "--no-nvram", "--removable"])
+    subprocess.run(args, check=False)
 
 
 def _grub_cfg_path() -> Path:
@@ -117,7 +116,7 @@ def _grub_cfg_path() -> Path:
 
 def _run_update_grub(*, grub_cfg_existed: bool) -> None:
     update_grub = shutil.which("update-grub")
-    if grub_cfg_existed and update_grub:
+    if ROOT == Path("/") and grub_cfg_existed and update_grub:
         subprocess.run([update_grub], check=False)
         return
 
@@ -131,8 +130,6 @@ def _run_update_grub(*, grub_cfg_existed: bool) -> None:
 
 
 def main() -> None:
-    if not _is_real_root():
-        return
     efi_dir = _efi_directory()
     grub_cfg = _grub_cfg_path()
     grub_cfg_existed = grub_cfg.exists()


### PR DESCRIPTION
### Motivation
- Ensure hooks always receive a canonical target root so hook scripts can reliably resolve target paths.
- Prevent hook runners and hook scripts from making host-global writes (EFI NVRAM, host /boot, initramfs, grub cfg) when operating against a non-root `LPM_ROOT`.
- Run grub tooling and bootstrap operations in the target context (chroot-like behavior or fully redirected target paths) instead of performing host actions by default.

### Description
- The hook transaction manager now injects a resolved `LPM_ROOT` into hook environments via `LPM_ROOT = str(self.root.resolve())` so hooks get a canonical target root. (See `src/lpm/hooks/__init__.py`.)
- `kernel-install` was changed to resolve `LPM_ROOT`, write GRUB output to `root / 'boot/grub/grub.cfg'` and to skip `bootctl update` when `root != '/'` to avoid host EFI variable writes. (See `usr/libexec/lpm/hooks/kernel-install`.)
- `update-grub` was updated to resolve `ROOT` and to run safely for non-root targets by: routing EFI mountpoint and grub paths into the target root, avoiding host `mount` calls for target roots, adding `--boot-directory`, `--no-nvram`, and `--removable` to `grub-install` when `ROOT != '/'`, and only invoking `update-grub` when running on real root otherwise generating the cfg directly under the target root. (See `usr/libexec/lpm/hooks/update-grub`.)
- Tests were added/adjusted in `tests/test_hooks.py` to validate mkinitcpio/grub behavior for non-`/` targets and to assert that hook commands do not reference or write to host `/boot` when `LPM_ROOT != '/'`.

### Testing
- Ran targeted kernel-related tests with `pytest -q tests/test_hooks.py -k 'kernel_install_hook or kernel_install_transaction_hook or kernel_modules_install_transaction_hook or update_grub_hook_runs_mkconfig_for_install or update_grub_hook_uses_target_paths_for_bootstrap'` and all selected tests passed. 
- Ran grub bootstrap and mkconfig tests with `pytest -q tests/test_hooks.py -k 'update_grub_hook_runs_update_tool_for_upgrade or update_grub_hook_runs_mkconfig_for_install'` and the selected tests passed. 
- Overall the modified `tests/test_hooks.py` assertions and the new bootstrap-path test pass locally against the updated hook scripts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f47e7c8188327803778778685deb1)