### PR TITLE
Add chroot API mount management with idempotent state tracking

### DIFF
--- a/src/lpm/bootstrap.py
+++ b/src/lpm/bootstrap.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Any, Dict, Iterable, Optional
+
+from lpm.chroot import ChrootMountState, mount_chroot_api, umount_chroot_api
+from typing import Any, Dict, Optional
 
 import tomllib
 
@@ -137,39 +138,15 @@ def completed_stages(state: Dict[str, Any]) -> set[str]:
     return {str(s) for s in raw if isinstance(s, str)}
 
 
-def _run_command(cfg: BootstrapConfig, cmd: Iterable[str]) -> None:
-    pretty = " ".join(cmd)
-    if cfg.dry_run:
-        print(f"[bootstrap][dry-run] shell: {pretty}")
-        return
-    subprocess.run(list(cmd), check=True)
-
-
-def _mount_api(cfg: BootstrapConfig, source: str, rel_target: str, mounts: list[Path]) -> None:
-    mountpoint = cfg.target / rel_target.lstrip("/")
-    if cfg.dry_run:
-        print(f"[bootstrap][dry-run] mount --bind {source} {mountpoint}")
-        mounts.append(mountpoint)
-        return
-    mountpoint.mkdir(parents=True, exist_ok=True)
-    _run_command(cfg, ["mount", "--bind", source, str(mountpoint)])
-    mounts.append(mountpoint)
-
-
-def _unmount_api(cfg: BootstrapConfig, mountpoint: Path) -> None:
-    if cfg.dry_run:
-        print(f"[bootstrap][dry-run] umount {mountpoint}")
-        return
-    _run_command(cfg, ["umount", str(mountpoint)])
-
-
-def _run_stage(cfg: BootstrapConfig, stage: Stage, api_mounts: list[Path]) -> None:
+def _run_stage(cfg: BootstrapConfig, stage: Stage, mount_state: ChrootMountState) -> None:
     _log(cfg, f"running stage={stage.value}")
     if stage == Stage.VALIDATE and not cfg.target.exists() and not cfg.dry_run:
         raise FileNotFoundError(f"target does not exist: {cfg.target}")
     if stage == Stage.PREPARE_DIRS:
-        for rel in ("proc", "sys", "dev"):
-            _mount_api(cfg, f"/{rel}", rel, api_mounts)
+        if cfg.dry_run:
+            print("[bootstrap][dry-run] mount chroot api filesystems")
+        else:
+            mount_chroot_api(cfg.target, mount_state)
     if stage == Stage.SEED_LPM:
         if cfg.dry_run:
             print("[bootstrap][dry-run] package plan: seed lpm into target")
@@ -181,20 +158,20 @@ def run_bootstrap(args: Any) -> int:
     cfg = load_config(args)
     state = load_state(cfg)
     done = completed_stages(state)
-    api_mounts: list[Path] = []
+    mount_state = ChrootMountState()
 
     try:
         for stage in STAGES:
             if cfg.resume and stage.value in done:
                 _log(cfg, f"skip completed stage={stage.value}")
                 continue
-            _run_stage(cfg, stage, api_mounts)
+            _run_stage(cfg, stage, mount_state)
             done.add(stage.value)
             save_state(cfg, {"completed_stages": sorted(done)})
         return 0
     finally:
-        for mountpoint in reversed(api_mounts):
+        if not cfg.dry_run:
             try:
-                _unmount_api(cfg, mountpoint)
+                umount_chroot_api(cfg.target, mount_state)
             except Exception as exc:
-                print(f"[bootstrap] warning: failed to unmount {mountpoint}: {exc}")
+                print(f"[bootstrap] warning: failed to unmount API mounts: {exc}")

--- a/src/lpm/chroot.py
+++ b/src/lpm/chroot.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import subprocess
+from typing import Iterable, List
+
+
+@dataclass(frozen=True)
+class MountSpec:
+    source: str
+    rel_target: str
+    fs_type: str
+    options: tuple[str, ...] = ()
+
+
+CHROOT_API_MOUNTS: tuple[MountSpec, ...] = (
+    MountSpec("proc", "proc", "proc"),
+    MountSpec("sysfs", "sys", "sysfs"),
+    MountSpec("/dev", "dev", "none", ("bind",)),
+    MountSpec("/dev/pts", "dev/pts", "none", ("bind",)),
+    MountSpec("tmpfs", "run", "tmpfs"),
+)
+
+
+@dataclass
+class ChrootMountState:
+    mounted: list[str] = field(default_factory=list)
+
+    def mark_mounted(self, rel_target: str) -> None:
+        if rel_target not in self.mounted:
+            self.mounted.append(rel_target)
+
+    def mark_unmounted(self, rel_target: str) -> None:
+        self.mounted = [m for m in self.mounted if m != rel_target]
+
+
+def _mount_table() -> set[str]:
+    points: set[str] = set()
+    with Path("/proc/self/mounts").open("r", encoding="utf-8") as fh:
+        for line in fh:
+            parts = line.split()
+            if len(parts) >= 2:
+                points.add(parts[1])
+    return points
+
+
+def _is_mounted(target: Path, known_mounts: set[str] | None = None) -> bool:
+    mounts = known_mounts if known_mounts is not None else _mount_table()
+    return str(target) in mounts
+
+
+def _mount_cmd(spec: MountSpec, target: Path) -> list[str]:
+    cmd = ["mount"]
+    if "bind" in spec.options:
+        cmd.extend(["--bind", spec.source, str(target)])
+        return cmd
+    cmd.extend(["-t", spec.fs_type, spec.source, str(target)])
+    return cmd
+
+
+def _run(cmd: Iterable[str]) -> None:
+    subprocess.run(list(cmd), check=True)
+
+
+def mount_chroot_api(target: str | Path, mount_state: ChrootMountState | None = None) -> ChrootMountState:
+    base = Path(target)
+    state = mount_state or ChrootMountState()
+    known_mounts = _mount_table()
+    newly_mounted: list[str] = []
+    try:
+        for spec in CHROOT_API_MOUNTS:
+            rel_target = spec.rel_target
+            mountpoint = base / rel_target
+            if rel_target in state.mounted or _is_mounted(mountpoint, known_mounts):
+                state.mark_mounted(rel_target)
+                continue
+            mountpoint.mkdir(parents=True, exist_ok=True)
+            _run(_mount_cmd(spec, mountpoint))
+            state.mark_mounted(rel_target)
+            known_mounts.add(str(mountpoint))
+            newly_mounted.append(rel_target)
+        return state
+    except Exception:
+        umount_chroot_api(base, ChrootMountState(mounted=newly_mounted))
+        raise
+
+
+def umount_chroot_api(target: str | Path, mount_state: ChrootMountState) -> ChrootMountState:
+    base = Path(target)
+    known_mounts = _mount_table()
+    for rel_target in reversed(mount_state.mounted):
+        mountpoint = base / rel_target
+        if not _is_mounted(mountpoint, known_mounts):
+            mount_state.mark_unmounted(rel_target)
+            continue
+        _run(["umount", str(mountpoint)])
+        mount_state.mark_unmounted(rel_target)
+        known_mounts.discard(str(mountpoint))
+    return mount_state

--- a/tests/test_chroot.py
+++ b/tests/test_chroot.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from lpm import chroot
+
+
+def test_is_mounted_detection(tmp_path: Path) -> None:
+    target = tmp_path / "root/proc"
+    assert chroot._is_mounted(target, {str(target)})
+    assert not chroot._is_mounted(target, set())
+
+
+def test_mount_chroot_api_avoids_double_mount(monkeypatch, tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(chroot, "_mount_table", lambda: {str(root / "proc")})
+    monkeypatch.setattr(chroot, "_run", lambda cmd: commands.append(list(cmd)))
+
+    state = chroot.mount_chroot_api(root)
+
+    assert str(root / "proc") not in " ".join(" ".join(c) for c in commands)
+    assert state.mounted == ["proc", "sys", "dev", "dev/pts", "run"]
+    assert len(commands) == 4
+
+
+def test_umount_chroot_api_reverse_order(monkeypatch, tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    called: list[str] = []
+    mounted = {
+        str(root / "proc"),
+        str(root / "sys"),
+        str(root / "dev"),
+        str(root / "dev/pts"),
+        str(root / "run"),
+    }
+
+    monkeypatch.setattr(chroot, "_mount_table", lambda: set(mounted))
+
+    def fake_run(cmd: list[str]) -> None:
+        called.append(cmd[-1])
+
+    monkeypatch.setattr(chroot, "_run", fake_run)
+
+    state = chroot.ChrootMountState(mounted=["proc", "sys", "dev", "dev/pts", "run"])
+    chroot.umount_chroot_api(root, state)
+
+    assert called == [
+        str(root / "run"),
+        str(root / "dev/pts"),
+        str(root / "dev"),
+        str(root / "sys"),
+        str(root / "proc"),
+    ]
+    assert state.mounted == []


### PR DESCRIPTION
### Motivation
- Provide a centralized, resume-safe helper for mounting chroot API filesystems (`proc`, `sys`, `/dev`, `/dev/pts`, `/run`) used during bootstrap preparation.
- Ensure mounts are idempotent by inspecting the mount table to avoid double-mounts when resuming or when some mounts already exist.
- Support partial-failure rollback so partially-applied mounts are cleaned on error.
- Ensure unmounting happens in strict reverse order to avoid dependency issues during teardown.

### Description
- Add `src/lpm/chroot.py` introducing `MountSpec`, `CHROOT_API_MOUNTS`, and `ChrootMountState` to track mounted relative targets.
- Implement mount-table inspection via `/proc/self/mounts` and `_is_mounted` checks, `_mount_cmd` and `_run` helpers, `mount_chroot_api(target, mount_state)` with idempotency and rollback, and `umount_chroot_api(target, mount_state)` that unmounts in reverse tracked order.
- Integrate the new helper into `src/lpm/bootstrap.py` to replace ad-hoc bind mounts during the `PREPARE_DIRS` stage and to use the `ChrootMountState` for exception-safe cleanup in `finally`.
- Add `tests/test_chroot.py` with tests for mount detection, avoiding double-mounts, and verifying reverse-order unmounting.

### Testing
- Ran `pytest -q tests/test_chroot.py tests/test_default_root_privileges.py` and the suite passed (`9 passed`).
- The new tests in `tests/test_chroot.py` exercise `_is_mounted`, `mount_chroot_api`, and `umount_chroot_api` and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f48c516f88327b6057c186b0883a2)