### PR TITLE
Enable `lpm buildpkg <name>` by resolving/fetching `.lpmbuild` scripts

### DIFF
--- a/src/lpm/app.py
+++ b/src/lpm/app.py
@@ -5551,9 +5551,25 @@ def cmd_buildpkg(a):
     if not a.script:
         die("buildpkg requires a .lpmbuild script or --python-pip")
 
-    script_path = Path(a.script)
+    raw_script = Path(a.script)
+    script_path = raw_script
     if not script_path.exists():
-        die(f".lpmbuild script not found: {script_path}")
+        candidate_name = raw_script.name
+        if candidate_name.endswith(".lpmbuild"):
+            candidate_name = candidate_name[:-len(".lpmbuild")]
+
+        local_candidate = _resolve_local_lpmbuild_script(candidate_name)
+        if local_candidate.exists():
+            script_path = local_candidate
+            ok(f"Resolved local lpmbuild script: {script_path}")
+        else:
+            fetched_script = Path(f"/tmp/lpm-{candidate_name}.lpmbuild")
+            fetch_fn = _resolve_lpm_attr("fetch_lpmbuild", fetch_lpmbuild)
+            try:
+                script_path = fetch_fn(candidate_name, fetched_script)
+                ok(f"Resolved repository lpmbuild script: {script_path}")
+            except Exception:
+                die(f".lpmbuild script not found: {raw_script}")
 
     run_lpmbuild_fn = _resolve_lpm_attr("run_lpmbuild", run_lpmbuild)
     with ThreadPoolExecutor(max_workers=worker_count) as executor:


### PR DESCRIPTION
## Summary
- Updated `cmd_buildpkg` so the positional argument can be either:
  - an existing script path, or
  - a package name (e.g. `gcc`) / script basename.
- When the provided value does not exist as a path, `buildpkg` now:
  1. Tries local repo script resolution via `packages/<name>/<name>.lpmbuild`.
  2. Falls back to fetching from the configured `LPMBUILD_REPO` into `/tmp/lpm-<name>.lpmbuild`.

## Behavior change
- `lpm buildpkg gcc` now resolves `gcc` to an lpmbuild script and proceeds with the normal build flow.
- Existing usage with explicit script paths is preserved.

## Files changed
- `src/lpm/app.py` (`cmd_buildpkg`)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f4b2b5618832782425eb95450bb28)