### PR TITLE
Use `lpm` for root installs and add package selection for bootstrap

### DIFF
--- a/src/lpm/bootstrap.py
+++ b/src/lpm/bootstrap.py
@@ -168,6 +168,27 @@ def generate_chroot_command(target: Path, command: list[str]) -> list[str]:
     return ["chroot", str(target), *command]
 
 
+def generate_lpm_root_install_command(target: Path, packages: list[str]) -> list[str]:
+    if not packages:
+        raise ValueError("at least one package is required for lpm root install")
+    return ["lpm", "--root", str(target), "install", *packages]
+
+
+def _bootstrap_packages(cfg: BootstrapConfig, kernel: str, network_backend: str, bootloader: str) -> list[str]:
+    raw = getattr(cfg, "base_packages", None)
+    if isinstance(raw, str):
+        custom = [p.strip() for p in raw.split(",") if p.strip()]
+        if custom:
+            return custom
+    if isinstance(raw, (list, tuple)):
+        custom = [str(p).strip() for p in raw if str(p).strip()]
+        if custom:
+            return custom
+    pkgs = ["basesystem", kernel, bootloader]
+    if network_backend in {"NetworkManager", "iwd"}:
+        pkgs.append("NetworkManager")
+    return pkgs
+
 def _as_path(value: Any) -> Optional[Path]:
     if value in (None, ""):
         return None
@@ -269,7 +290,7 @@ def _run_stage(cfg: BootstrapConfig, stage: Stage, mount_state: ChrootMountState
     if stage == Stage.VALIDATE:
         if not cfg.target.exists() and not cfg.dry_run:
             raise FileNotFoundError(f"target does not exist: {cfg.target}")
-        missing = [tool for tool in ("dnf", "chroot", "mount", "umount") if shutil.which(tool) is None]
+        missing = [tool for tool in ("lpm", "chroot", "mount", "umount") if shutil.which(tool) is None]
         if missing:
             raise RuntimeError(f"missing required tools: {', '.join(missing)}")
         if boot_mode not in {"uefi", "bios"}:
@@ -305,8 +326,7 @@ def _run_stage(cfg: BootstrapConfig, stage: Stage, mount_state: ChrootMountState
             subprocess.run(["cp", "-a", f"{src_root}/.", str(dst_root)], check=True)
 
     elif stage == Stage.INSTALL_BASE:
-        base_pkgs = ["basesystem", "kernel", kernel, "grub", "NetworkManager"]
-        cmd = ["dnf", "-y", "--installroot", str(cfg.target), "install", *base_pkgs]
+        cmd = generate_lpm_root_install_command(cfg.target, _bootstrap_packages(cfg, kernel, network_backend, bootloader))
         if cfg.dry_run:
             print(f"[bootstrap][dry-run] {' '.join(cmd)}")
         else:

--- a/tests/test_bootstrap_configure.py
+++ b/tests/test_bootstrap_configure.py
@@ -44,3 +44,30 @@ def test_state_tracking_dry_run(tmp_path: Path) -> None:
 def test_grub_install_requires_boot_device_for_bios() -> None:
     with pytest.raises(ValueError):
         bootstrap.grub_install_command("bios", None, None)
+
+
+def test_generate_lpm_root_install_command() -> None:
+    cmd = bootstrap.generate_lpm_root_install_command(Path('/mnt'), ['basesystem', 'linux'])
+    assert cmd == ['lpm', '--root', '/mnt', 'install', 'basesystem', 'linux']
+
+
+def test_generate_lpm_root_install_command_requires_packages() -> None:
+    with pytest.raises(ValueError):
+        bootstrap.generate_lpm_root_install_command(Path('/mnt'), [])
+
+
+def test_install_base_uses_lpm_not_dnf(monkeypatch, tmp_path: Path) -> None:
+    cfg = bootstrap.BootstrapConfig(target=tmp_path, bootloader='grub', kernel='linux')
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, check=True, **kwargs):
+        calls.append(list(cmd))
+        class Result:
+            returncode = 0
+        return Result()
+
+    monkeypatch.setattr(bootstrap.subprocess, 'run', fake_run)
+    bootstrap._run_stage(cfg, bootstrap.Stage.INSTALL_BASE, bootstrap.ChrootMountState())
+    assert calls
+    assert calls[0][0] == 'lpm'
+    assert 'dnf' not in calls[0]


### PR DESCRIPTION
### Motivation
- Move from `dnf` to the distribution-local `lpm` tool for installing the base system during bootstrap.
- Allow configuration of the base package list via `BootstrapConfig.base_packages` with flexible string or list input.

### Description
- Add `generate_lpm_root_install_command` to build `lpm --root <target> install ...` commands and validate non-empty package lists.
- Introduce `_bootstrap_packages` to derive the package list from `BootstrapConfig.base_packages` (accepting comma-separated strings or lists) and include kernel, bootloader, and network package heuristics.
- Replace the `dnf` install invocation in the `INSTALL_BASE` stage with a call to `generate_lpm_root_install_command(cfg.target, _bootstrap_packages(...))`.
- Update validation to require the `lpm` binary instead of `dnf` and add related tests.

### Testing
- Added unit tests `test_generate_lpm_root_install_command`, `test_generate_lpm_root_install_command_requires_packages`, and `test_install_base_uses_lpm_not_dnf` in `tests/test_bootstrap_configure.py` which exercise command generation and ensure the runtime uses `lpm` (using `monkeypatch` to stub `subprocess.run`).
- Ran `pytest tests/test_bootstrap_configure.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a159efceeac83278ca469d63d8901a1)