### PR TITLE
Add installroot workflow with safety checks, chroot API mounts, and tests

### DIFF
--- a/src/lpm/app.py
+++ b/src/lpm/app.py
@@ -7001,6 +7001,7 @@ def build_parser()->argparse.ArgumentParser:
     sp.add_argument("--manifest", help="path to package manifest input")
     sp.add_argument("--cache-dir", default=CACHE_DIR, help="package cache directory")
     sp.add_argument("--dry-run", action="store_true")
+    sp.add_argument("--mount-api", action="store_true", help="mount /proc,/sys,/dev in target root during install")
     sp.add_argument("--verbose", action="store_true")
     sp.set_defaults(func=cmd_installroot)
 

--- a/src/lpm/chroot_helpers.py
+++ b/src/lpm/chroot_helpers.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import json
+import subprocess
 from pathlib import Path
 from typing import Any
+
+from lpm.bootstrap import _safe_target, generate_lpm_root_install_command
+from lpm.chroot import ChrootMountState, mount_chroot_api, umount_chroot_api
 
 
 def _echo(message: str, *, verbose: bool = False) -> None:
@@ -11,6 +16,53 @@ def _echo(message: str, *, verbose: bool = False) -> None:
 
 def _normalize_root(root: str | None) -> Path:
     return Path(root or "/")
+
+
+def _read_manifest_packages(manifest: str | None) -> list[str]:
+    if not manifest:
+        return []
+    path = Path(manifest)
+    if not path.exists():
+        raise ValueError(f"manifest not found: {path}")
+    packages: list[str] = []
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        packages.append(line)
+    return packages
+
+
+def _collect_packages(args: Any) -> list[str]:
+    cli_packages = list(getattr(args, "packages", []) or [])
+    manifest_packages = _read_manifest_packages(getattr(args, "manifest", None))
+    combined = cli_packages + manifest_packages
+    if not combined:
+        raise ValueError("installroot requires --package or --manifest")
+    return combined
+
+
+def _run_root_install(target_root: Path, packages: list[str], *, dry_run: bool = False) -> dict[str, Any]:
+    cmd = generate_lpm_root_install_command(target_root, packages)
+    result: dict[str, Any] = {
+        "target_root": str(target_root),
+        "packages_requested": packages,
+        "command": cmd,
+        "dry_run": dry_run,
+        "installed": [],
+        "failed": [],
+        "returncode": 0,
+    }
+    if dry_run:
+        return result
+
+    proc = subprocess.run(cmd, check=False)
+    result["returncode"] = proc.returncode
+    if proc.returncode == 0:
+        result["installed"] = packages
+    else:
+        result["failed"] = packages
+    return result
 
 
 def run_bootstrap_chroot(args: Any) -> int:
@@ -36,21 +88,31 @@ def run_bootstrap_chroot(args: Any) -> int:
 def run_installroot(args: Any) -> int:
     root = _normalize_root(getattr(args, "root", None))
     cache_dir = Path(args.cache_dir)
-    packages = list(getattr(args, "packages", []) or [])
-    manifest = getattr(args, "manifest", None)
     verbose = bool(getattr(args, "verbose", False))
+    mount_api = bool(getattr(args, "mount_api", False))
 
-    if not packages and not manifest:
-        raise ValueError("installroot requires --package or --manifest")
+    _safe_target(root)
+    packages = _collect_packages(args)
 
     _echo(f"[installroot] root={root} cache={cache_dir}", verbose=verbose)
+    mount_state = ChrootMountState(mounted=[])
     if args.dry_run:
-        _echo("[installroot] dry-run enabled; no filesystem changes", verbose=verbose)
+        result = _run_root_install(root, packages, dry_run=True)
+        print(json.dumps(result, indent=2, sort_keys=True))
         return 0
 
     root.mkdir(parents=True, exist_ok=True)
     cache_dir.mkdir(parents=True, exist_ok=True)
-    return 0
+
+    try:
+        if mount_api:
+            mount_state = mount_chroot_api(root, mount_state)
+        result = _run_root_install(root, packages)
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return int(result["returncode"])
+    finally:
+        if mount_api:
+            umount_chroot_api(root, mount_state)
 
 
 def run_buildgen(args: Any) -> int:

--- a/tests/test_installroot.py
+++ b/tests/test_installroot.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from lpm import app
+from lpm import chroot_helpers
+
+
+def test_installroot_parser_arguments() -> None:
+    parser = app.build_parser()
+    args = parser.parse_args([
+        "installroot",
+        "--root",
+        "/tmp/target",
+        "--package",
+        "base",
+        "--manifest",
+        "pkgs.txt",
+        "--mount-api",
+        "--dry-run",
+    ])
+
+    assert args.cmd == "installroot"
+    assert args.root == "/tmp/target"
+    assert args.packages == ["base"]
+    assert args.manifest == "pkgs.txt"
+    assert args.mount_api is True
+    assert args.dry_run is True
+
+
+def test_run_root_install_generates_expected_command(monkeypatch, tmp_path) -> None:
+    calls: list[list[str]] = []
+
+    class Proc:
+        returncode = 0
+
+    def fake_run(cmd, check=False):
+        calls.append(cmd)
+        return Proc()
+
+    monkeypatch.setattr(chroot_helpers.subprocess, "run", fake_run)
+
+    result = chroot_helpers._run_root_install(tmp_path, ["basesystem", "linux"])
+
+    assert calls == [["lpm", "--root", str(tmp_path), "install", "basesystem", "linux"]]
+    assert result["installed"] == ["basesystem", "linux"]
+    assert result["failed"] == []
+    assert result["returncode"] == 0
+
+
+def test_installroot_dry_run_outputs_structured_summary(tmp_path, capsys) -> None:
+    manifest = tmp_path / "manifest.txt"
+    manifest.write_text("# comment\nlinux\nvim\n", encoding="utf-8")
+
+    args = SimpleNamespace(
+        root=str(tmp_path / "target"),
+        cache_dir=str(tmp_path / "cache"),
+        packages=["basesystem"],
+        manifest=str(manifest),
+        mount_api=False,
+        dry_run=True,
+        verbose=False,
+    )
+
+    rc = chroot_helpers.run_installroot(args)
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["dry_run"] is True
+    assert payload["target_root"] == str(tmp_path / "target")
+    assert payload["packages_requested"] == ["basesystem", "linux", "vim"]
+    assert payload["command"] == [
+        "lpm",
+        "--root",
+        str(tmp_path / "target"),
+        "install",
+        "basesystem",
+        "linux",
+        "vim",
+    ]
+
+
+def test_installroot_requires_package_or_manifest(tmp_path) -> None:
+    args = SimpleNamespace(
+        root=str(tmp_path / "target"),
+        cache_dir=str(tmp_path / "cache"),
+        packages=[],
+        manifest=None,
+        mount_api=False,
+        dry_run=True,
+        verbose=False,
+    )
+
+    with pytest.raises(ValueError, match="installroot requires --package or --manifest"):
+        chroot_helpers.run_installroot(args)


### PR DESCRIPTION
### Motivation
- Provide a repeatable, safe wrapper for performing root (chroot/DESTDIR) installs that can be reused by bootstrap flows and tooling. 
- Ensure installs into an arbitrary target root validate safety, optionally mount chroot API filesystems, and emit a machine-readable summary for downstream consumption.

### Description
- Implemented `installroot` workflow in `src/lpm/chroot_helpers.py` that collects package names from `--package` and `--manifest`, parses manifests (skips comments/blank lines), and validates the target with `_safe_target` before proceeding. 
- Added `_run_root_install` which uses `generate_lpm_root_install_command` to build the `lpm --root <target> install ...` command, invokes it with `subprocess.run`, and returns a structured result payload with `target_root`, `packages_requested`, `command`, `installed`, `failed`, and `returncode`. 
- Added optional API filesystem lifecycle management using `mount_chroot_api` and `umount_chroot_api` when `--mount-api` is supplied, and ensured dry-run mode prints JSON summary only. 
- Extended CLI parser in `src/lpm/app.py` to accept `--mount-api` for the `installroot` subcommand and added tests in `tests/test_installroot.py` covering argument parsing, install command generation, dry-run JSON output, and input validation.

### Testing
- Ran `pytest -q tests/test_installroot.py` which passed (`4 passed`).
- Ran `pytest -q tests/test_installroot.py tests/test_bootstrap_configure.py` which reported a failure in an existing bootstrap test (`tests/test_bootstrap_configure.py::test_install_base_uses_lpm_not_dnf`) unrelated to the new `installroot` tests; the new tests themselves passed in isolation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f48621288327bc9497a22fb7311e)