### PR TITLE
Add buildgen/buildchroot manifest-driven build pipeline

### DIFF
--- a/src/lpm/chroot_helpers.py
+++ b/src/lpm/chroot_helpers.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, Iterable, List, Mapping, Sequence, Set, Tuple
 
 
 def _echo(message: str, *, verbose: bool = False) -> None:
@@ -11,6 +13,100 @@ def _echo(message: str, *, verbose: bool = False) -> None:
 
 def _normalize_root(root: str | None) -> Path:
     return Path(root or "/")
+
+
+@dataclass(frozen=True)
+class BuildManifestEntry:
+    name: str
+    script: str
+    requires: Tuple[str, ...]
+    build_requires: Tuple[str, ...]
+
+    def as_dict(self) -> Dict[str, object]:
+        return {
+            "name": self.name,
+            "script": self.script,
+            "requires": list(self.requires),
+            "build_requires": list(self.build_requires),
+        }
+
+
+def _parse_dep_names(requirements: Sequence[str]) -> Tuple[str, ...]:
+    from . import app
+
+    names: Set[str] = set()
+    for raw in requirements:
+        try:
+            expr = app.parse_dep_expr(raw)
+        except Exception:
+            continue
+        atoms = app.flatten_and(expr) if expr.kind == "and" else [expr]
+        for atom_expr in atoms:
+            if atom_expr.kind != "atom" or atom_expr.atom is None:
+                continue
+            dep_name = (atom_expr.atom.name or "").strip()
+            if dep_name:
+                names.add(dep_name)
+    return tuple(sorted(names))
+
+
+def _discover_lpmbuild_scripts(source: Path) -> List[Path]:
+    if source.is_file():
+        return [source]
+    if not source.exists():
+        return []
+    return sorted(source.glob("**/*.lpmbuild"), key=lambda p: str(p.relative_to(source)))
+
+
+def _build_manifest_entries(source: Path, scripts: Iterable[Path]) -> Dict[str, BuildManifestEntry]:
+    from . import app
+
+    entries: Dict[str, BuildManifestEntry] = {}
+    for script in sorted(scripts, key=lambda p: str(p)):
+        scalars, arrays, _maps = app._capture_lpmbuild_metadata(script)
+        name = (scalars.get("NAME") or "").strip()
+        if not name:
+            continue
+        rel_script = str(script.relative_to(source if source.is_dir() else script.parent.parent))
+        requires = _parse_dep_names(list(arrays.get("REQUIRES", [])))
+        build_requires = _parse_dep_names(list(arrays.get("BUILD_REQUIRES", [])))
+        entries[name] = BuildManifestEntry(
+            name=name,
+            script=rel_script,
+            requires=requires,
+            build_requires=build_requires,
+        )
+    return entries
+
+
+def _order_manifest(entries: Mapping[str, BuildManifestEntry]) -> Tuple[List[str], List[List[str]]]:
+    nodes = sorted(entries.keys())
+    edges: Dict[str, Set[str]] = {name: set() for name in nodes}
+    indegree: Dict[str, int] = {name: 0 for name in nodes}
+    for name, entry in entries.items():
+        for dep in sorted(set(entry.requires) | set(entry.build_requires)):
+            if dep not in entries:
+                continue
+            edges[dep].add(name)
+            indegree[name] += 1
+
+    ready = sorted([name for name, degree in indegree.items() if degree == 0])
+    ordered: List[str] = []
+    while ready:
+        cur = ready.pop(0)
+        ordered.append(cur)
+        for nxt in sorted(edges[cur]):
+            indegree[nxt] -= 1
+            if indegree[nxt] == 0:
+                ready.append(nxt)
+        ready.sort()
+
+    if len(ordered) == len(nodes):
+        return ordered, []
+
+    unresolved = {name for name in nodes if indegree[name] > 0}
+    cycle_groups = [[name] for name in sorted(unresolved)]
+    return ordered, cycle_groups
 
 
 def run_bootstrap_chroot(args: Any) -> int:
@@ -64,7 +160,26 @@ def run_buildgen(args: Any) -> int:
         _echo("[buildgen] dry-run enabled; no filesystem changes", verbose=verbose)
         return 0
 
+    scripts = _discover_lpmbuild_scripts(source)
+    if not scripts:
+        raise ValueError(f"No .lpmbuild scripts found under {source}")
+
+    entries = _build_manifest_entries(source, scripts)
+    ordered, cycle_groups = _order_manifest(entries)
+    if cycle_groups:
+        groups = "; ".join(", ".join(group) for group in cycle_groups)
+        raise ValueError(
+            "Cycle detected in buildgen dependency graph. "
+            f"Cycle groups: {groups}"
+        )
+
     output_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = output_dir / "build-manifest.json"
+    payload = {
+        "source": str(source),
+        "packages": [entries[name].as_dict() for name in ordered],
+    }
+    manifest_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return 0
 
 
@@ -83,7 +198,37 @@ def run_buildchroot(args: Any) -> int:
         _echo("[buildchroot] dry-run enabled; no filesystem changes", verbose=verbose)
         return 0
 
+    manifest_path = output_dir / "build-manifest.json"
+    if not manifest_path.exists():
+        raise ValueError(f"build manifest not found: {manifest_path}")
+
+    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    packages = data.get("packages") if isinstance(data, dict) else None
+    if not isinstance(packages, list):
+        raise ValueError(f"invalid build manifest: {manifest_path}")
+
+    from . import app
+
+    source_root = source if source.is_dir() else source.parent
+
     root.mkdir(parents=True, exist_ok=True)
     cache_dir.mkdir(parents=True, exist_ok=True)
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    for idx, pkg in enumerate(packages, start=1):
+        if not isinstance(pkg, dict):
+            continue
+        name = str(pkg.get("name") or "")
+        rel_script = str(pkg.get("script") or "")
+        script = source_root / rel_script
+        if not script.exists():
+            raise ValueError(f"Missing .lpmbuild scripts for buildchroot targets: {name} ({script})")
+        _echo(f"[buildchroot {idx}/{len(packages)}] {name}", verbose=verbose)
+        app.run_lpmbuild(
+            script,
+            outdir=cache_dir,
+            prompt_install=False,
+            build_deps=True,
+            fetcher=app.fetch_lpmbuild,
+        )
     return 0

--- a/tests/test_build_chroot_helpers.py
+++ b/tests/test_build_chroot_helpers.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from lpm import chroot_helpers
+from lpm import app
+
+
+def _write_script(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+
+
+def test_buildgen_manifest_deterministic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = tmp_path / "packages"
+    output = tmp_path / "out"
+    a = source / "alpha" / "alpha.lpmbuild"
+    b = source / "beta" / "beta.lpmbuild"
+    _write_script(a)
+    _write_script(b)
+
+    meta = {
+        str(a): ({"NAME": "alpha"}, {"REQUIRES": [], "BUILD_REQUIRES": []}, {}),
+        str(b): ({"NAME": "beta"}, {"REQUIRES": ["alpha>=1"], "BUILD_REQUIRES": []}, {}),
+    }
+
+    monkeypatch.setattr(app, "_capture_lpmbuild_metadata", lambda script: meta[str(script)])
+
+    args = Namespace(root=str(tmp_path / "root"), source=str(source), output_dir=str(output), dry_run=False, verbose=False)
+    chroot_helpers.run_buildgen(args)
+    first = (output / "build-manifest.json").read_text(encoding="utf-8")
+
+    chroot_helpers.run_buildgen(args)
+    second = (output / "build-manifest.json").read_text(encoding="utf-8")
+
+    assert first == second
+    payload = json.loads(first)
+    assert [pkg["name"] for pkg in payload["packages"]] == ["alpha", "beta"]
+
+
+def test_buildgen_cycle_detection(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = tmp_path / "packages"
+    output = tmp_path / "out"
+    a = source / "alpha" / "alpha.lpmbuild"
+    b = source / "beta" / "beta.lpmbuild"
+    _write_script(a)
+    _write_script(b)
+
+    meta = {
+        str(a): ({"NAME": "alpha"}, {"REQUIRES": ["beta"], "BUILD_REQUIRES": []}, {}),
+        str(b): ({"NAME": "beta"}, {"REQUIRES": ["alpha"], "BUILD_REQUIRES": []}, {}),
+    }
+    monkeypatch.setattr(app, "_capture_lpmbuild_metadata", lambda script: meta[str(script)])
+
+    args = Namespace(root=str(tmp_path / "root"), source=str(source), output_dir=str(output), dry_run=False, verbose=False)
+    with pytest.raises(ValueError, match="Cycle detected in buildgen dependency graph"):
+        chroot_helpers.run_buildgen(args)
+
+
+def test_buildchroot_missing_script(tmp_path: Path) -> None:
+    source = tmp_path / "packages"
+    out = tmp_path / "out"
+    out.mkdir(parents=True)
+    (out / "build-manifest.json").write_text(
+        json.dumps({"source": str(source), "packages": [{"name": "alpha", "script": "alpha/alpha.lpmbuild"}]}),
+        encoding="utf-8",
+    )
+
+    args = Namespace(
+        root=str(tmp_path / "root"),
+        source=str(source),
+        cache_dir=str(tmp_path / "cache"),
+        output_dir=str(out),
+        dry_run=False,
+        verbose=False,
+    )
+
+    with pytest.raises(ValueError, match=r"Missing \.lpmbuild scripts"):
+        chroot_helpers.run_buildchroot(args)


### PR DESCRIPTION
### Motivation
- Provide a reproducible way to discover and order local `.lpmbuild` packages for chroot builds and avoid duplicating resolver/fetch logic.
- Surface cycle detection and missing-script errors early, with messaging consistent with existing rebuild tooling.

### Description
- Implemented `buildgen` in `src/lpm/chroot_helpers.py` to discover `.lpmbuild` scripts, capture metadata via `app._capture_lpmbuild_metadata`, extract dependency names using existing `parse_dep_expr`/`flatten_and`, and emit a deterministic `build-manifest.json` listing packages in dependency order.
- Added simple topological ordering and cycle reporting (`_order_manifest`) that returns ordered packages or grouped cycle information and raises a clear error on cycles mirroring rebuild message style.
- Implemented `buildchroot` to consume `build-manifest.json`, validate entries and script paths, and build packages in manifest order by invoking the existing `run_lpmbuild` with `fetch_lpmbuild` as the fetcher to avoid duplicating logic.
- Added explicit error reporting when referenced `.lpmbuild` scripts are missing and structured manifest entries as `BuildManifestEntry` with stable serialization.
- Modified `src/lpm/chroot_helpers.py` and added tests at `tests/test_build_chroot_helpers.py` to cover manifest determinism, cycle detection, and missing-script behavior.

### Testing
- Ran unit tests: `pytest -q tests/test_build_chroot_helpers.py` and all tests passed (`3 passed`).
- The new tests verify deterministic manifest output, cycle detection raises a `ValueError`, and `buildchroot` raises on missing scripts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f4baced08327b150cf741c87742d)