### PR TITLE
Add buildgen manifest generation and buildchroot execution

### DIFF
--- a/src/lpm/chroot_helpers.py
+++ b/src/lpm/chroot_helpers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -126,7 +127,75 @@ def run_buildgen(args: Any) -> int:
         _echo("[buildgen] dry-run enabled; no filesystem changes", verbose=verbose)
         return 0
 
+    from lpm import app as lpm_app
+
+    scripts = sorted(source.glob("*/**/*.lpmbuild")) if source.is_dir() else []
+    if not scripts:
+        raise ValueError(f"no .lpmbuild scripts found under: {source}")
+
+    meta_by_pkg: dict[str, dict[str, Any]] = {}
+    deps_by_pkg: dict[str, set[str]] = {}
+    for script in scripts:
+        scal, arr, _maps = lpm_app._capture_lpmbuild_metadata(script)
+        name = str(scal.get("NAME") or scal.get("name") or "").strip()
+        if not name:
+            continue
+        dep_fields = []
+        for key in ("REQUIRES", "requires", "BUILD_REQUIRES", "build_requires"):
+            dep_fields.extend([str(x) for x in (arr.get(key) or []) if x])
+        dep_names: set[str] = set()
+        for raw in dep_fields:
+            try:
+                dep_names.add(lpm_app.parse_dep_expr(raw).name)
+                continue
+            except Exception:
+                pass
+            token = str(raw).strip().split()[0] if str(raw).strip() else ""
+            token = token.split(">=")[0].split("<=")[0].split("=")[0].split("<")[0].split(">")[0]
+            if token:
+                dep_names.add(token)
+        meta_by_pkg[name] = {
+            "name": name,
+            "version": str(scal.get("VERSION") or scal.get("version") or ""),
+            "script": str(script),
+            "depends": sorted(dep_names),
+        }
+        deps_by_pkg[name] = set(dep_names)
+
+    known = set(meta_by_pkg)
+    for name, deps in deps_by_pkg.items():
+        deps.intersection_update(known)
+        meta_by_pkg[name]["depends"] = sorted(deps)
+
+    indeg = {k: 0 for k in known}
+    rev: dict[str, set[str]] = {k: set() for k in known}
+    for pkg in sorted(known):
+        for dep in sorted(deps_by_pkg[pkg]):
+            indeg[pkg] += 1
+            rev[dep].add(pkg)
+    queue = sorted([k for k, d in indeg.items() if d == 0])
+    order: list[str] = []
+    while queue:
+        cur = queue.pop(0)
+        order.append(cur)
+        for nxt in sorted(rev[cur]):
+            indeg[nxt] -= 1
+            if indeg[nxt] == 0:
+                queue.append(nxt)
+                queue.sort()
+    if len(order) != len(known):
+        remaining = sorted([k for k, d in indeg.items() if d > 0])
+        raise ValueError("Cycle detected in buildgen dependency graph. Cycle groups: " + ", ".join(remaining))
+
     output_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "source": str(source),
+        "package_order": order,
+        "packages": [meta_by_pkg[n] for n in order],
+    }
+    manifest_path = output_dir / "build-manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(str(manifest_path))
     return 0
 
 
@@ -145,7 +214,33 @@ def run_buildchroot(args: Any) -> int:
         _echo("[buildchroot] dry-run enabled; no filesystem changes", verbose=verbose)
         return 0
 
+    from lpm import app as lpm_app
+
+    manifest_path = output_dir / "build-manifest.json"
+    if manifest_path.exists():
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    else:
+        tmp_args = type("BuildGenArgs", (), {
+            "root": str(root), "source": str(source), "output_dir": str(output_dir), "dry_run": False, "verbose": verbose
+        })()
+        run_buildgen(tmp_args)
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    packages = manifest.get("packages", []) or []
+    missing = [p.get("script") for p in packages if not Path(str(p.get("script", ""))).exists()]
+    if missing:
+        raise ValueError("Missing .lpmbuild scripts for build targets: " + ", ".join(sorted(str(x) for x in missing)))
+
     root.mkdir(parents=True, exist_ok=True)
     cache_dir.mkdir(parents=True, exist_ok=True)
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    staged_repo = output_dir / "repo"
+    staged_repo.mkdir(parents=True, exist_ok=True)
+    for idx, pkg in enumerate(packages, start=1):
+        name = str(pkg.get("name", ""))
+        script = Path(str(pkg.get("script", "")))
+        print(f"[buildchroot {idx}/{len(packages)}] {name}")
+        blob, _elapsed, _size, _splits = lpm_app.run_lpmbuild(script, outdir=cache_dir, prompt_install=False, build_deps=True)
+        shutil.copy2(blob, staged_repo / Path(blob).name)
     return 0

--- a/tests/test_buildgen_buildchroot.py
+++ b/tests/test_buildgen_buildchroot.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from lpm import chroot_helpers
+
+
+def test_buildgen_manifest_is_deterministic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    src = tmp_path / "packages"
+    for name in ("a", "b"):
+        p = src / name / f"{name}.lpmbuild"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("# stub\n", encoding="utf-8")
+
+    from lpm import app as lpm_app
+
+    def fake_capture(path: Path):
+        if path.stem == "a":
+            return {"NAME": "a", "VERSION": "1"}, {"REQUIRES": ["b"]}, {}
+        return {"NAME": "b", "VERSION": "1"}, {"REQUIRES": []}, {}
+
+    monkeypatch.setattr(lpm_app, "_capture_lpmbuild_metadata", fake_capture)
+
+    out1 = tmp_path / "out1"
+    out2 = tmp_path / "out2"
+    args1 = Namespace(root=str(tmp_path / "root"), source=str(src), output_dir=str(out1), dry_run=False, verbose=False)
+    args2 = Namespace(root=str(tmp_path / "root"), source=str(src), output_dir=str(out2), dry_run=False, verbose=False)
+
+    assert chroot_helpers.run_buildgen(args1) == 0
+    assert chroot_helpers.run_buildgen(args2) == 0
+
+    m1 = json.loads((out1 / "build-manifest.json").read_text(encoding="utf-8"))
+    m2 = json.loads((out2 / "build-manifest.json").read_text(encoding="utf-8"))
+    assert m1["package_order"] == ["b", "a"]
+    assert m1 == m2
+
+
+def test_buildgen_cycle_detection(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    src = tmp_path / "packages"
+    for name in ("a", "b"):
+        p = src / name / f"{name}.lpmbuild"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("# stub\n", encoding="utf-8")
+
+    from lpm import app as lpm_app
+
+    def fake_capture(path: Path):
+        if path.stem == "a":
+            return {"NAME": "a", "VERSION": "1"}, {"REQUIRES": ["b"]}, {}
+        return {"NAME": "b", "VERSION": "1"}, {"REQUIRES": ["a"]}, {}
+
+    monkeypatch.setattr(lpm_app, "_capture_lpmbuild_metadata", fake_capture)
+    args = Namespace(root=str(tmp_path / "root"), source=str(src), output_dir=str(tmp_path / "out"), dry_run=False, verbose=False)
+
+    with pytest.raises(ValueError, match="Cycle detected in buildgen dependency graph"):
+        chroot_helpers.run_buildgen(args)
+
+
+def test_buildchroot_missing_script_fails(tmp_path: Path) -> None:
+    out = tmp_path / "out"
+    out.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "package_order": ["demo"],
+        "packages": [{"name": "demo", "script": str(tmp_path / "missing.lpmbuild"), "depends": []}],
+    }
+    (out / "build-manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    args = Namespace(
+        root=str(tmp_path / "root"),
+        source=str(tmp_path / "packages"),
+        cache_dir=str(tmp_path / "cache"),
+        output_dir=str(out),
+        dry_run=False,
+        verbose=False,
+    )
+    with pytest.raises(ValueError, match="Missing .lpmbuild scripts for build targets"):
+        chroot_helpers.run_buildchroot(args)


### PR DESCRIPTION
## Summary
- implement `buildgen` to discover `.lpmbuild` scripts, extract metadata, derive deterministic dependency order, and emit `build-manifest.json`
- implement `buildchroot` to consume that manifest, validate script presence, run `run_lpmbuild` in manifest order, and stage built artifacts into an output repo directory
- reuse existing lpmbuild logic from `lpm.app` (`_capture_lpmbuild_metadata`, dependency parsing, `run_lpmbuild`) without duplicating build execution/fetch behavior
- add cycle and missing-script error reporting for build graph preflight
- add tests for deterministic manifest generation, cycle detection, and buildchroot behavior when scripts are missing

## Testing
- `PYTHONPATH=src pytest -q tests/test_buildgen_buildchroot.py`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16328c7e1c8327935d1262a8fafbbd)