### PR TITLE
Finish buildchroot flow and install built package set

### DIFF
--- a/src/lpm/chroot_helpers.py
+++ b/src/lpm/chroot_helpers.py
@@ -237,10 +237,18 @@ def run_buildchroot(args: Any) -> int:
 
     staged_repo = output_dir / "repo"
     staged_repo.mkdir(parents=True, exist_ok=True)
+    built_package_names: list[str] = []
     for idx, pkg in enumerate(packages, start=1):
         name = str(pkg.get("name", ""))
         script = Path(str(pkg.get("script", "")))
         print(f"[buildchroot {idx}/{len(packages)}] {name}")
         blob, _elapsed, _size, _splits = lpm_app.run_lpmbuild(script, outdir=cache_dir, prompt_install=False, build_deps=True)
         shutil.copy2(blob, staged_repo / Path(blob).name)
-    return 0
+        if name:
+            built_package_names.append(name)
+
+    # Populate the target chroot with the packages represented by the
+    # lpmbuild set so a fresh root can be brought up directly from sources.
+    install_result = _run_root_install(root, built_package_names)
+    print(json.dumps(install_result, indent=2, sort_keys=True))
+    return int(install_result.get("returncode", 0))

--- a/tests/test_buildgen_buildchroot.py
+++ b/tests/test_buildgen_buildchroot.py
@@ -79,3 +79,48 @@ def test_buildchroot_missing_script_fails(tmp_path: Path) -> None:
     )
     with pytest.raises(ValueError, match="Missing .lpmbuild scripts for build targets"):
         chroot_helpers.run_buildchroot(args)
+
+
+def test_buildchroot_installs_built_packages(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    script = tmp_path / "packages" / "demo" / "demo.lpmbuild"
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_text("# demo\n", encoding="utf-8")
+
+    out = tmp_path / "out"
+    out.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "package_order": ["demo"],
+        "packages": [{"name": "demo", "script": str(script), "depends": []}],
+    }
+    (out / "build-manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    built_blob = tmp_path / "cache" / "demo-1-any.zst"
+
+    from lpm import app as lpm_app
+
+    def fake_run_lpmbuild(*_args, **_kwargs):
+        built_blob.parent.mkdir(parents=True, exist_ok=True)
+        built_blob.write_text("blob", encoding="utf-8")
+        return built_blob, 0.0, built_blob.stat().st_size, []
+
+    install_calls: list[list[str]] = []
+
+    def fake_run_root_install(_root: Path, packages: list[str], *, dry_run: bool = False):
+        install_calls.append(list(packages))
+        return {"returncode": 0, "dry_run": dry_run}
+
+    monkeypatch.setattr(lpm_app, "run_lpmbuild", fake_run_lpmbuild)
+    monkeypatch.setattr(chroot_helpers, "_run_root_install", fake_run_root_install)
+
+    args = Namespace(
+        root=str(tmp_path / "root"),
+        source=str(tmp_path / "packages"),
+        cache_dir=str(tmp_path / "cache"),
+        output_dir=str(out),
+        dry_run=False,
+        verbose=False,
+    )
+    rc = chroot_helpers.run_buildchroot(args)
+    assert rc == 0
+    assert install_calls == [["demo"]]
+    assert (out / "repo" / built_blob.name).exists()


### PR DESCRIPTION
## Summary
- completed `run_buildchroot` so it now installs the built package set into the target chroot root after staging artifacts
- retained manifest-based deterministic build ordering and repo staging behavior
- returned the install command status from buildchroot for proper CLI success/failure signaling

## Tests
- added `test_buildchroot_installs_built_packages` to verify built package names are installed into the target root and the staged repo artifact is created
- existing missing-script failure test remains unchanged

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17673e2e248327acc9654e396cb788)