### PR TITLE
Use atomic policy-backed writes for buildpkg metadata files

### DIFF
--- a/src/lpm/app.py
+++ b/src/lpm/app.py
@@ -231,7 +231,7 @@ from installgen import generate_install_script
 from first_run_ui import run_first_run_wizard
 import maintainer_mode
 from . import config as _config
-from .atomic_io import atomic_replace
+from .atomic_io import atomic_replace, safe_write
 from .fs_ops import operation_phase
 from .privileges import privilege_info, privileged_section, privileges_enabled
 from .resolver import CNF, CDCLSolver
@@ -2580,10 +2580,16 @@ def build_package(stagedir: Path, meta: PkgMeta, out: Path, sign=True):
     mani_path = stagedir / ".lpm-manifest.json"
     meta_dict = dataclasses.asdict(meta)
 
-    with meta_path.open("w", encoding="utf-8") as f:
-        json.dump(meta_dict, f, indent=2, sort_keys=True)
-    with mani_path.open("w", encoding="utf-8") as f:
-        json.dump(mani, f, indent=2)
+    safe_write(
+        meta_path,
+        json.dumps(meta_dict, ensure_ascii=False, indent=2, sort_keys=True),
+        mode=0o644,
+    )
+    safe_write(
+        mani_path,
+        json.dumps(mani, ensure_ascii=False, indent=2),
+        mode=0o644,
+    )
 
     # Package with tar + zstd (with Python fallback)
     if use_fallback:

--- a/tests/test_buildpkg_metadata_files.py
+++ b/tests/test_buildpkg_metadata_files.py
@@ -1,0 +1,55 @@
+import dataclasses
+import json
+import os
+import stat
+from pathlib import Path
+
+import lpm.app as app
+
+
+def _meta() -> app.PkgMeta:
+    return app.PkgMeta(name="demo", version="1.0", release="1", arch="noarch")
+
+
+def _fake_run(*args, **kwargs):
+    return None
+
+
+def test_build_package_writes_metadata_files_with_expected_content(monkeypatch, tmp_path):
+    stagedir = tmp_path / "stage"
+    stagedir.mkdir()
+    (stagedir / "usr").mkdir()
+    (stagedir / "usr" / "hello.txt").write_text("hello\n", encoding="utf-8")
+
+    monkeypatch.setattr(app.shutil, "which", lambda cmd: "zstd")
+    monkeypatch.setattr(app.subprocess, "run", _fake_run)
+
+    meta = _meta()
+    app.build_package(stagedir, meta, tmp_path / "demo.zst", sign=False)
+
+    meta_path = stagedir / ".lpm-meta.json"
+    mani_path = stagedir / ".lpm-manifest.json"
+
+    assert json.loads(meta_path.read_text(encoding="utf-8"))["name"] == "demo"
+    assert json.loads(mani_path.read_text(encoding="utf-8"))[0]["path"] == "/usr/hello.txt"
+
+
+def test_build_package_metadata_permissions_ignore_umask(monkeypatch, tmp_path):
+    stagedir = tmp_path / "stage"
+    stagedir.mkdir()
+    (stagedir / "payload.txt").write_text("payload", encoding="utf-8")
+
+    monkeypatch.setattr(app.shutil, "which", lambda cmd: "zstd")
+    monkeypatch.setattr(app.subprocess, "run", _fake_run)
+
+    previous_umask = os.umask(0o077)
+    try:
+        app.build_package(stagedir, _meta(), tmp_path / "demo.zst", sign=False)
+    finally:
+        os.umask(previous_umask)
+
+    meta_mode = stat.S_IMODE((stagedir / ".lpm-meta.json").stat().st_mode)
+    mani_mode = stat.S_IMODE((stagedir / ".lpm-manifest.json").stat().st_mode)
+
+    assert meta_mode == 0o644
+    assert mani_mode == 0o644


### PR DESCRIPTION
### Motivation
- Ensure metadata file creation in `build_package(...)` follows the same internal filesystem policy used elsewhere to avoid partial files and to respect enforced umask/ownership semantics.

### Description
- Replaced direct `Path.open(...)/json.dump(...)` writes for `.lpm-meta.json` and `.lpm-manifest.json` in `src/lpm/app.py` with `safe_write(...)` calls and added `safe_write` to the imports.
- Preserved existing JSON formatting and ordering by using `json.dumps(..., indent=2, sort_keys=True)` for the meta file and `json.dumps(..., indent=2)` for the manifest, and kept the write order as `meta` then `manifest`.
- Applied explicit file mode `0o644` to both metadata files and relied on `safe_write` for atomic writes so partial files are not left on interruption.
- Added `tests/test_buildpkg_metadata_files.py` to validate metadata/manifest contents and deterministic `0o644` permissions under a restrictive `umask`.

### Testing
- Ran `pytest -q tests/test_buildpkg_metadata_files.py` and the new tests passed (`2 passed`).
- The change is localized to `src/lpm/app.py` and the added test file `tests/test_buildpkg_metadata_files.py`, and no other automated test runs were performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1821d064708327a0726aa14ae80eba)