### PR TITLE
Unify packaging directory setup through fs_ops.prepare_directory

### DIFF
--- a/src/lpm/app.py
+++ b/src/lpm/app.py
@@ -232,7 +232,7 @@ from first_run_ui import run_first_run_wizard
 import maintainer_mode
 from . import config as _config
 from .atomic_io import atomic_replace, safe_write
-from .fs_ops import operation_phase
+from .fs_ops import operation_phase, prepare_directory
 from .privileges import privilege_info, privileged_section, privileges_enabled
 from .resolver import CNF, CDCLSolver
 from .hooks import HookExecutionError, HookFailureMode, HookTransactionManager, _ensure_executable, load_hooks
@@ -4276,18 +4276,18 @@ def run_lpmbuild(
     srcroot_base = Path(f"/tmp/src-{name}")
 
     def _prepare_directory(base: Path, *, label: str) -> Path:
-        try:
-            if base.exists():
-                shutil.rmtree(base)
-            base.mkdir(parents=True, exist_ok=True)
-            return base
-        except PermissionError as exc:
+        prepared = prepare_directory(
+            base,
+            privileged=True,
+            reset=True,
+            fallback_prefix=f"lpm-{label}-{name}-",
+        )
+        if prepared != base:
             warn(
-                "[lpm] Permission denied while preparing %s (%s); "
-                "falling back to a temporary directory" % (base, exc)
+                "[lpm] Permission denied while preparing %s; "
+                "falling back to a temporary directory %s" % (base, prepared)
             )
-            fallback = Path(tempfile.mkdtemp(prefix=f"lpm-{label}-{name}-"))
-            return fallback
+        return prepared
 
     stagedir = _prepare_directory(stagedir_base, label="pkg")
     buildroot = _prepare_directory(buildroot_base, label="build")
@@ -4558,7 +4558,7 @@ def run_lpmbuild(
                 target_name = alias or os.path.basename(source_ref.rstrip("/"))
                 if target_name:
                     target_path = srcroot / target_name
-                    target_path.parent.mkdir(parents=True, exist_ok=True)
+                    prepare_directory(target_path.parent, privileged=False)
                     shutil.copy2(local_candidate, target_path)
                 continue
 
@@ -4571,7 +4571,7 @@ def run_lpmbuild(
                 target_name = alias or os.path.basename(source_ref.rstrip("/"))
                 if target_name:
                     target_path = srcroot / target_name
-                    target_path.parent.mkdir(parents=True, exist_ok=True)
+                    prepare_directory(target_path.parent, privileged=False)
                     shutil.copy2(local_candidate, target_path)
                 continue
 
@@ -4629,7 +4629,7 @@ def run_lpmbuild(
 
     if archive_path is not None:
         target_dir = srcroot / f"{name}-{version}"
-        target_dir.mkdir(parents=True, exist_ok=True)
+        prepare_directory(target_dir, privileged=False)
 
         def _extract_with_tarfile(path: Path, dest: Path) -> None:
             def _strip_member(name: str) -> Optional[str]:
@@ -5418,7 +5418,7 @@ def cmd_splitpkg(a):
         out = Path(a.output)
     else:
         out = outdir / f"{meta.name}-{meta.version}-{meta.release}.{meta.arch}{EXT}"
-    out.parent.mkdir(parents=True, exist_ok=True)
+    prepare_directory(out.parent, privileged=False)
 
     install_sh = stagedir / ".lpm-install.sh"
     if install_sh.exists():

--- a/src/lpm/fs_ops.py
+++ b/src/lpm/fs_ops.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import shutil
+import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional, Union
@@ -15,15 +17,42 @@ def operation_phase(privileged: bool = True):
 
     managers = []
     try:
+        managers.append(enforce_umask(0o022))
         if privileged:
             managers.append(privileged_section())
-            managers.append(enforce_umask(0o022))
         for cm in managers:
             cm.__enter__()
         yield
     finally:
         for cm in reversed(managers):
             cm.__exit__(None, None, None)
+
+
+def prepare_directory(
+    path: Union[str, Path],
+    *,
+    privileged: bool,
+    reset: bool = False,
+    fallback_prefix: Optional[str] = None,
+) -> Path:
+    """Create *path* with deterministic umask and optional reset/fallback behavior.
+
+    When *privileged* is ``True`` this runs in an elevated section and typically
+    yields root-owned directories. When ``False`` it runs under current
+    privileges and ownership follows the current effective user.
+    """
+
+    target = Path(path)
+    try:
+        with operation_phase(privileged=privileged):
+            if reset and target.exists():
+                shutil.rmtree(target)
+            target.mkdir(parents=True, exist_ok=True)
+        return target
+    except PermissionError:
+        if not fallback_prefix:
+            raise
+        return Path(tempfile.mkdtemp(prefix=fallback_prefix))
 
 
 def write_db_json(path: Union[str, Path], obj: Any) -> Path:
@@ -103,6 +132,7 @@ def materialize_from_manifest(
 
 __all__ = [
     "operation_phase",
+    "prepare_directory",
     "write_db_json",
     "write_db_bytes",
     "write_manifest_file",

--- a/tests/test_default_root_privileges.py
+++ b/tests/test_default_root_privileges.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from lpm import app as lpm
+from lpm.fs_ops import prepare_directory
 
 
 def _raise_die(message: str, _code: int = 2):
@@ -125,3 +126,16 @@ def test_removepkg_default_root_dry_run_does_not_use_privileged_section(monkeypa
 
     lpm.removepkg("demo", root=Path(lpm.DEFAULT_ROOT), dry_run=True)
     assert calls == []
+
+
+def test_prepare_directory_permission_fallback(tmp_path, monkeypatch):
+    target = tmp_path / "blocked"
+    fallback = tmp_path / "fallback-dir"
+
+    def _raise_mkdir(*_args, **_kwargs):
+        raise PermissionError("blocked")
+
+    monkeypatch.setattr(Path, "mkdir", _raise_mkdir)
+    monkeypatch.setattr(lpm.tempfile, "mkdtemp", lambda prefix: str(fallback))
+    result = prepare_directory(target, privileged=True, reset=True, fallback_prefix="lpm-test-")
+    assert result == fallback

--- a/tests/test_state_permissions.py
+++ b/tests/test_state_permissions.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 import sys
 from pathlib import Path
 
@@ -27,3 +28,16 @@ def test_state_db_is_group_writable(tmp_path, monkeypatch):
     assert (state_dir.stat().st_mode & 0o777) == 0o775
     assert (db_path.stat().st_mode & 0o777) == 0o664
 
+
+def test_operation_phase_enforces_umask_for_unprivileged(tmp_path):
+    from src.lpm.fs_ops import operation_phase
+
+    probe = tmp_path / "probe"
+    original = os.umask(0o077)
+    try:
+        with operation_phase(privileged=False):
+            probe.mkdir()
+    finally:
+        os.umask(original)
+
+    assert (probe.stat().st_mode & 0o777) == 0o755


### PR DESCRIPTION
### Motivation

- Ensure packaging-time directory creation/removal is deterministic across privileged/unprivileged flows and host umask differences. 
- Consolidate ad-hoc `mkdir`/reset/fallback logic used in the build/package pipeline into a single helper to make ownership/privilege expectations explicit. 
- Reduce duplication and make permission-fallback behavior consistent when preparing staging, build, src, and output parent directories.

### Description

- Add `prepare_directory(path, *, privileged: bool, reset: bool = False, fallback_prefix: Optional[str] = None) -> Path` to `src/lpm/fs_ops.py`, which runs directory creation inside `operation_phase(privileged=...)`, enforces deterministic umask, supports optional reset, and returns a fallback tempdir on `PermissionError` when `fallback_prefix` is provided. 
- Make `operation_phase(...)` enforce `umask 0o022` for both privileged and unprivileged phases by always entering `enforce_umask(0o022)` and then optionally `privileged_section()`. 
- Wire `prepare_directory` into the packaging pipeline in `src/lpm/app.py`: replace the local `_prepare_directory` implementation to call `prepare_directory(...)` (with `privileged=True`, `reset=True`, `fallback_prefix`), and replace ad-hoc `mkdir(...)` calls in packaging paths with `prepare_directory(..., privileged=False)` for source staging parent directories, archive extraction targets, and split-package output parent (`out.parent`). 
- Add tests to assert the new behavior: a permission-denied fallback test (`test_prepare_directory_permission_fallback`) in `tests/test_default_root_privileges.py` and a deterministic umask test for unprivileged `operation_phase` (`test_operation_phase_enforces_umask_for_unprivileged`) in `tests/test_state_permissions.py`.

### Testing

- Ran `pytest -q tests/test_default_root_privileges.py tests/test_state_permissions.py` and got all tests passing: `9 passed`.
- Ran `pytest -q tests/test_buildpkg_no_deps.py` and got `3 passed`.
- The added tests are `test_prepare_directory_permission_fallback` and `test_operation_phase_enforces_umask_for_unprivileged`, and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1822c741248327a805a2af5f898c67)