### PR TITLE
Add tomli fallback for Python<3.11 and update bootstrap tests/pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,9 @@ readme = "README.md"
 authors = [{ name = "Derek Midkiff" }]
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
-dependencies = []
+dependencies = [
+    "tomli>=2.0.0; python_version < '3.11'",
+]
 
 [project.optional-dependencies]
 ui = ["PySide6>=6.6"]

--- a/src/lpm/bootstrap.py
+++ b/src/lpm/bootstrap.py
@@ -5,6 +5,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from enum import Enum
@@ -14,7 +15,10 @@ from typing import Any, Dict, Optional
 
 from lpm.chroot import ChrootMountState, mount_chroot_api, umount_chroot_api
 
-import tomllib
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - exercised on Python 3.10
+    import tomli as tomllib
 
 
 class Stage(str, Enum):

--- a/tests/test_bootstrap_configure.py
+++ b/tests/test_bootstrap_configure.py
@@ -41,6 +41,20 @@ def test_state_tracking_dry_run(tmp_path: Path) -> None:
     assert not cfg.state_path.exists()
 
 
+def test_parse_toml_reads_bootstrap_section(tmp_path: Path) -> None:
+    config = tmp_path / "bootstrap.toml"
+    config.write_text(
+        "[bootstrap]\n"
+        "target = '/mnt/lumin'\n"
+        "hostname = 'lumin'\n",
+        encoding="utf-8",
+    )
+
+    data = bootstrap._parse_toml(config)
+
+    assert data == {"target": "/mnt/lumin", "hostname": "lumin"}
+
+
 def test_grub_install_requires_boot_device_for_bios() -> None:
     with pytest.raises(ValueError):
         bootstrap.grub_install_command("bios", None, None)
@@ -67,7 +81,7 @@ def test_install_base_uses_lpm_not_dnf(monkeypatch, tmp_path: Path) -> None:
         return Result()
 
     monkeypatch.setattr(bootstrap.subprocess, 'run', fake_run)
-    bootstrap._run_stage(cfg, bootstrap.Stage.INSTALL_BASE, bootstrap.ChrootMountState())
+    bootstrap._run_stage(cfg, bootstrap.Stage.INSTALL_BASE, bootstrap.ChrootMountState(), {})
     assert calls
     assert calls[0][0] == 'lpm'
     assert 'dnf' not in calls[0]


### PR DESCRIPTION
### Motivation
- Ensure TOML parsing works on Python 3.10 by providing a compatible fallback to `tomli` when `tomllib` is unavailable.
- Declare the `tomli` runtime dependency for interpreters older than 3.11 in `pyproject.toml` so installs on those versions include the parser.
- Update tests to assert the new parser behavior and to match an adjusted `_run_stage` call signature used in bootstrap tests.

### Description
- Added `import sys` and a conditional import that uses `tomllib` on Python >= 3.11 and imports `tomli as tomllib` otherwise in `src/lpm/bootstrap.py`.
- Added `"tomli>=2.0.0; python_version < '3.11'"` to the `dependencies` section in `pyproject.toml`.
- Added a new unit test `test_parse_toml_reads_bootstrap_section` in `tests/test_bootstrap_configure.py` to validate TOML parsing of the `[bootstrap]` section.
- Updated `test_install_base_uses_lpm_not_dnf` to call `_run_stage` with an additional argument (an empty dict) to reflect the adjusted call signature used by the bootstrap logic.

### Testing
- Ran the updated test module with `pytest tests/test_bootstrap_configure.py` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a182647b5c48327925cd9d0aa9ac919)