### PR TITLE
Handle first-run config permission failures

### DIFF
--- a/src/first_run_ui.py
+++ b/src/first_run_ui.py
@@ -11,6 +11,19 @@ from typing import Callable, Dict, Iterable, Mapping, Optional, TextIO
 from lpm import config
 
 
+class FirstRunSetupError(RuntimeError):
+    """Raised when first-run setup cannot persist a usable configuration."""
+
+
+def permission_denied_message(conf_path: Path) -> str:
+    """Return actionable guidance for configuration write permission failures."""
+
+    return (
+        f'Permission denied writing {conf_path}. '
+        'Re-run "sudo lpm setup" or create the config as root.'
+    )
+
+
 @dataclass(frozen=True)
 class ConfigField:
     """Description of an interactive configuration field."""
@@ -583,10 +596,16 @@ def run_first_run_wizard(
             selections[field.key] = value
 
     output_stream.write("\nSaving configuration...\n")
-    config.save_conf(selections, path=conf_path)
+    try:
+        config.save_conf(selections, path=conf_path)
+    except PermissionError as exc:
+        message = permission_denied_message(conf_path)
+        output_stream.write(f"{message}\n")
+        output_stream.flush()
+        raise FirstRunSetupError(message) from exc
     output_stream.write(f"Configuration written to {conf_path}\n")
     output_stream.flush()
     return selections
 
 
-__all__ = ["run_first_run_wizard"]
+__all__ = ["FirstRunSetupError", "permission_denied_message", "run_first_run_wizard"]

--- a/src/lpm/app.py
+++ b/src/lpm/app.py
@@ -228,7 +228,7 @@ from .config import (
 initialize_state()
 from fs import read_json, write_json, urlread
 from installgen import generate_install_script
-from first_run_ui import run_first_run_wizard
+from first_run_ui import FirstRunSetupError, run_first_run_wizard
 import maintainer_mode
 from . import config as _config
 from .atomic_io import atomic_replace, safe_write
@@ -7048,14 +7048,16 @@ def main(argv=None):
     if cmd is None:
         parser.error("a subcommand is required")
     conf_file = _resolve_lpm_attr("CONF_FILE", CONF_FILE)
-    if cmd != "setup" and not conf_file.exists():
-        _resolve_lpm_attr("run_first_run_wizard", run_first_run_wizard)()
     try:
+        if cmd != "setup" and not conf_file.exists():
+            _resolve_lpm_attr("run_first_run_wizard", run_first_run_wizard)()
         if cmd in _PRIVILEGED_COMMANDS:
             with operation_phase(privileged=True):
                 args.func(args)
         else:
             args.func(args)
+    except FirstRunSetupError as e:
+        die(str(e))
     except ResolutionError as e:
         die(f"dependency resolution failed: {e}")
 

--- a/tests/test_first_run_setup.py
+++ b/tests/test_first_run_setup.py
@@ -3,6 +3,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import lpm
@@ -33,6 +35,64 @@ def test_main_triggers_setup_when_conf_missing(monkeypatch, tmp_path):
 
     assert captured.get("called") is True
     assert conf_path.exists()
+
+
+def test_wizard_permission_denied_reports_actionable_message(monkeypatch, tmp_path):
+    conf_path = tmp_path / "etc" / "lpm" / "lpm.conf"
+    output = io.StringIO()
+
+    monkeypatch.setattr(first_run_ui, "_build_fields", lambda: ([], []))
+
+    def deny_save(settings, *, path):
+        raise PermissionError("blocked")
+
+    monkeypatch.setattr(first_run_ui.config, "save_conf", deny_save)
+
+    with pytest.raises(first_run_ui.FirstRunSetupError) as excinfo:
+        first_run_ui.run_first_run_wizard(
+            conf_path=conf_path,
+            input_stream=io.StringIO(),
+            output_stream=output,
+            metadata={"version": "test", "build": "test", "build_date": ""},
+            init_system="unknown",
+            cpu_info={
+                "vendor": "",
+                "family": "",
+                "march": "generic",
+                "mtune": "generic",
+            },
+        )
+
+    text = output.getvalue()
+    assert str(conf_path) in text
+    assert "sudo lpm setup" in text
+    assert str(conf_path) in str(excinfo.value)
+    assert "sudo lpm setup" in str(excinfo.value)
+
+
+def test_main_reports_first_run_setup_errors_without_traceback(monkeypatch, tmp_path, capsys):
+    import importlib
+
+    app = importlib.import_module("lpm.app")
+
+    conf_path = tmp_path / "missing.conf"
+    message = first_run_ui.permission_denied_message(conf_path)
+
+    def fake_wizard(*args, **kwargs):
+        raise app.FirstRunSetupError(message)
+
+    monkeypatch.setattr(lpm, "CONF_FILE", conf_path, raising=False)
+    monkeypatch.setattr(lpm, "run_first_run_wizard", fake_wizard)
+    monkeypatch.setattr(lpm, "cmd_repolist", lambda args: None)
+
+    with pytest.raises(SystemExit) as excinfo:
+        lpm.main(["repolist"])
+
+    captured = capsys.readouterr()
+    assert excinfo.value.code == 2
+    assert str(conf_path) in captured.err
+    assert "sudo lpm setup" in captured.err
+    assert "Traceback" not in captured.err
 
 
 def test_setup_command_runs_wizard_and_writes_config(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation
- Ensure interactive first-run setup shows a clear, actionable message instead of a traceback when writing `/etc/lpm/lpm.conf` fails due to permissions.
- Provide the same guidance whether the wizard is run directly via `lpm setup` or invoked automatically for other commands when the config is missing.

### Description
- Added `FirstRunSetupError` and a helper `permission_denied_message(conf_path: Path)` in `src/first_run_ui.py` to centralize the permission-denied guidance that mentions the config path and `sudo lpm setup`.
- Wrapped `config.save_conf(selections, path=conf_path)` in `run_first_run_wizard()` with `try/except PermissionError` to write the concise guidance to the wizard `output_stream` and raise `FirstRunSetupError`.
- Updated `src/lpm/app.py::main()` to catch `FirstRunSetupError` and route it through the existing `die()` error-reporting mechanism so the CLI prints the guidance without a traceback.
- Added tests to `tests/test_first_run_setup.py` that simulate `config.save_conf()` raising `PermissionError` and assert both the wizard output and the top-level CLI error mention the config path and `sudo lpm setup`.

### Testing
- Ran `pytest -q tests/test_first_run_setup.py tests/test_config_save.py` and all tests passed (`7 passed`).
- Verified the new tests exercise both the wizard permission path and the automatic first-run CLI reporting and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1860d4537c83279f3f4b6f9aa1d269)