### PR TITLE
Ensure first-run setup wizard runs with elevated privileges

### DIFF
--- a/src/lpm/app.py
+++ b/src/lpm/app.py
@@ -6562,7 +6562,8 @@ def cmd_protected(a):
 
 
 def cmd_setup(_):
-    _resolve_lpm_attr("run_first_run_wizard", run_first_run_wizard)()
+    with operation_phase(privileged=True):
+        _resolve_lpm_attr("run_first_run_wizard", run_first_run_wizard)()
 
 
 # =========================== Maintainer spec generation =======================
@@ -7050,7 +7051,8 @@ def main(argv=None):
     conf_file = _resolve_lpm_attr("CONF_FILE", CONF_FILE)
     try:
         if cmd != "setup" and not conf_file.exists():
-            _resolve_lpm_attr("run_first_run_wizard", run_first_run_wizard)()
+            with operation_phase(privileged=True):
+                _resolve_lpm_attr("run_first_run_wizard", run_first_run_wizard)()
         if cmd in _PRIVILEGED_COMMANDS:
             with operation_phase(privileged=True):
                 args.func(args)

--- a/tests/test_first_run_setup.py
+++ b/tests/test_first_run_setup.py
@@ -1,3 +1,4 @@
+import contextlib
 import io
 import json
 import sys
@@ -10,6 +11,118 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import lpm
 import src.config as config
 import src.first_run_ui as first_run_ui
+
+
+@contextlib.contextmanager
+def _recording_operation_phase(events, *, active_uid=None):
+    events.append(("enter", True, active_uid["current"] if active_uid else None))
+    previous_uid = None
+    if active_uid is not None:
+        previous_uid = active_uid["current"]
+        active_uid["current"] = active_uid["privileged"]
+    try:
+        yield
+    finally:
+        if active_uid is not None:
+            active_uid["current"] = previous_uid
+        events.append(("exit", True, active_uid["current"] if active_uid else None))
+
+
+def test_setup_command_enters_privileged_section_before_wizard(monkeypatch):
+    import importlib
+
+    app = importlib.import_module("lpm.app")
+    events = []
+
+    def fake_operation_phase(*, privileged=True):
+        assert privileged is True
+        return _recording_operation_phase(events)
+
+    def fake_wizard(*args, **kwargs):
+        events.append(("wizard", None, None))
+        return {"ARCH": "x86_64"}
+
+    monkeypatch.setattr(app, "operation_phase", fake_operation_phase)
+    monkeypatch.setattr(app, "run_first_run_wizard", fake_wizard)
+
+    lpm.main(["setup"])
+
+    assert events == [
+        ("enter", True, None),
+        ("wizard", None, None),
+        ("exit", True, None),
+    ]
+
+
+def test_auto_setup_enters_privileged_section_before_wizard(monkeypatch, tmp_path):
+    import importlib
+
+    app = importlib.import_module("lpm.app")
+    conf_path = tmp_path / "missing.conf"
+    events = []
+
+    def fake_operation_phase(*, privileged=True):
+        assert privileged is True
+        return _recording_operation_phase(events)
+
+    def fake_wizard(*args, **kwargs):
+        events.append(("wizard", None, None))
+        conf_path.write_text("ARCH=x86_64\n", encoding="utf-8")
+        return {"ARCH": "x86_64"}
+
+    def fake_repolist(args):
+        events.append(("command", None, None))
+
+    monkeypatch.setattr(app, "CONF_FILE", conf_path, raising=False)
+    monkeypatch.setattr(lpm, "CONF_FILE", conf_path, raising=False)
+    monkeypatch.setattr(app, "operation_phase", fake_operation_phase)
+    monkeypatch.setattr(app, "run_first_run_wizard", fake_wizard)
+    monkeypatch.setattr(app, "cmd_repolist", fake_repolist)
+
+    lpm.main(["repolist"])
+
+    assert events == [
+        ("enter", True, None),
+        ("wizard", None, None),
+        ("exit", True, None),
+        ("command", None, None),
+    ]
+
+
+def test_auto_setup_re_drops_sudo_style_privileges_before_command(monkeypatch, tmp_path):
+    import importlib
+
+    app = importlib.import_module("lpm.app")
+    conf_path = tmp_path / "missing.conf"
+    # Simulate the privilege manager's sudo path: the process started as root,
+    # then module initialization dropped the effective UID before command work.
+    active_uid = {"started": 0, "privileged": 0, "current": 1000}
+    seen = []
+
+    def fake_operation_phase(*, privileged=True):
+        assert privileged is True
+        return _recording_operation_phase(seen, active_uid=active_uid)
+
+    def fake_wizard(*args, **kwargs):
+        seen.append(("wizard_euid", active_uid["current"]))
+        conf_path.write_text("ARCH=x86_64\n", encoding="utf-8")
+        return {"ARCH": "x86_64"}
+
+    def fake_repolist(args):
+        seen.append(("command_euid", active_uid["current"]))
+
+    monkeypatch.setattr(app, "CONF_FILE", conf_path, raising=False)
+    monkeypatch.setattr(lpm, "CONF_FILE", conf_path, raising=False)
+    monkeypatch.setattr(app, "operation_phase", fake_operation_phase)
+    monkeypatch.setattr(app, "run_first_run_wizard", fake_wizard)
+    monkeypatch.setattr(app, "cmd_repolist", fake_repolist)
+
+    lpm.main(["repolist"])
+
+    assert active_uid["started"] == 0
+    assert ("wizard_euid", 0) in seen
+    assert ("command_euid", 1000) in seen
+    assert active_uid["current"] == 1000
 
 
 def test_main_triggers_setup_when_conf_missing(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation
- The first-run configuration wizard may need root access to create system config files, so it must execute inside a privileged operation phase to avoid permission errors and provide correct guidance.
- Also need to preserve the sudo-style privilege manager behavior where the process may start privileged then drop effective UID before normal command execution.

### Description
- Wrap the explicit `setup` subcommand wizard invocation in `operation_phase(privileged=True)` in `src/lpm/app.py` (`cmd_setup`).
- Wrap the automatic missing-config first-run wizard path in `operation_phase(privileged=True)` in `src/lpm/app.py` (`main`) before dispatching the requested command.
- Kept `_PRIVILEGED_COMMANDS` unchanged to avoid double-wrapping; applied explicit wrappers near the wizard calls instead.
- Added tests in `tests/test_first_run_setup.py` asserting that `lpm.main(["setup"])` and the missing-config auto-setup enter a privileged section before calling the wizard, and a regression test that simulates the sudo-style privilege-drop path to ensure privileges are elevated for the wizard and dropped again for the subsequent command.

### Testing
- Ran `pytest -q tests/test_first_run_setup.py tests/test_privileges.py` and the test suite passed (all tests succeeded).
- Also executed the focused test `tests/test_first_run_setup.py::test_setup_command_runs_wizard_and_writes_config` during iteration to validate interactive wizard behavior, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18bcc1295c8327bffa97e7c63850eb)