### PR TITLE
Add root privilege helpers to privileges.py

### DIFF
--- a/src/lpm/privileges.py
+++ b/src/lpm/privileges.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import os
+import shlex
+import sys
 import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -125,6 +127,23 @@ class _PrivilegeManager:
                 self._drop_privileges()
 
 
+def is_root() -> bool:
+    return os.geteuid() == 0
+
+
+def format_rerun_hint() -> str:
+    args = [shlex.quote(arg) for arg in sys.argv]
+    return "sudo " + " ".join(args)
+
+
+def require_root(action: str) -> None:
+    if is_root():
+        return
+    print(f"lpm: {action} requires root privileges", file=sys.stderr)
+    print(f"try: {format_rerun_hint()}", file=sys.stderr)
+    raise SystemExit(1)
+
+
 _MANAGER = _PrivilegeManager()
 
 
@@ -156,6 +175,9 @@ def state_owner_ids() -> tuple[Optional[int], Optional[int]]:
 
 
 __all__ = [
+    "is_root",
+    "format_rerun_hint",
+    "require_root",
     "privileged_section",
     "privileges_enabled",
     "privilege_info",

--- a/tests/test_privileges.py
+++ b/tests/test_privileges.py
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from typing import List, Tuple
 
+import pytest
+
 
 def _reload_privileges(monkeypatch, *, real_ids, effective_ids, env_ids=None):
     real_uid, real_gid = real_ids
@@ -97,5 +99,56 @@ def test_privileged_section_disabled_without_elevation(monkeypatch):
             pass
 
         assert calls == []
+    finally:
+        cleanup()
+
+
+def test_format_rerun_hint_quotes_sys_argv(monkeypatch):
+    module, _calls, cleanup = _reload_privileges(
+        monkeypatch,
+        real_ids=(1000, 1000),
+        effective_ids=(1000, 1000),
+    )
+    try:
+        monkeypatch.setattr(sys, "argv", ["lpm", "install", "pkg with space", "it's"])
+
+        assert module.format_rerun_hint() == (
+            "sudo lpm install 'pkg with space' 'it'\"'\"'s'"
+        )
+    finally:
+        cleanup()
+
+
+def test_require_root_exits_with_rerun_hint(monkeypatch, capsys):
+    module, _calls, cleanup = _reload_privileges(
+        monkeypatch,
+        real_ids=(1000, 1000),
+        effective_ids=(1000, 1000),
+    )
+    try:
+        monkeypatch.setattr(sys, "argv", ["lpm", "remove", "pkg name"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            module.require_root("remove")
+
+        assert exc_info.value.code == 1
+        assert capsys.readouterr().err == (
+            "lpm: remove requires root privileges\n"
+            "try: sudo lpm remove 'pkg name'\n"
+        )
+    finally:
+        cleanup()
+
+
+def test_require_root_returns_for_root(monkeypatch, capsys):
+    module, _calls, cleanup = _reload_privileges(
+        monkeypatch,
+        real_ids=(0, 0),
+        effective_ids=(0, 0),
+    )
+    try:
+        module.require_root("install")
+
+        assert capsys.readouterr().err == ""
     finally:
         cleanup()


### PR DESCRIPTION
### Motivation
- Provide small, reusable helpers for detecting root, formatting a sudo re-run hint, and enforcing root requirements for CLI actions.
- Surface these helpers from the `privileges` module so other code can produce consistent error messages and hints when root is required.

### Description
- Added `import shlex` and `import sys` to `src/lpm/privileges.py` and implemented `is_root()`, `format_rerun_hint()`, and `require_root(action: str)`.
- `format_rerun_hint()` quotes each `sys.argv` element with `shlex.quote()` and returns a `sudo ...` invocation string, and `require_root()` prints the error and hint to `sys.stderr` then exits with `SystemExit(1)` when not running as root.
- Exported the new names in `__all__` and left existing functions (`privileged_section()`, `privileges_enabled()`, `privilege_info()`, and `state_owner_ids()`) and the `_PrivilegeManager` behavior unchanged.
- Added tests in `tests/test_privileges.py` to verify quoting behavior and `require_root()` behavior for both non-root and root cases.

### Testing
- Ran `python -m compileall src/lpm/privileges.py tests/test_privileges.py` which compiled without errors.
- Ran `python -m pytest tests/test_privileges.py` and all new and existing tests in that file passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a190b25c0fc83279ae9c3a700569a33)