### PR TITLE
Gate privileged CLI commands before package operations

### DIFF
--- a/src/lpm/app.py
+++ b/src/lpm/app.py
@@ -232,7 +232,7 @@ import maintainer_mode
 from . import config as _config
 from .atomic_io import atomic_replace, safe_write
 from .fs_ops import operation_phase, prepare_directory
-from .privileges import privilege_info, privileged_section, privileges_enabled
+from .privileges import privilege_info, privileged_section, privileges_enabled, require_root
 from .resolver import CNF, CDCLSolver
 from .hooks import HookExecutionError, HookFailureMode, HookTransactionManager, _ensure_executable, load_hooks
 from .delta import apply_delta, find_cached_by_sha, file_sha256, zstd_version, version_at_least
@@ -4899,7 +4899,15 @@ def run_lpmbuild(
     return out, duration, phase_count, split_records
 
 # =========================== CLI commands =====================================
-_PRIVILEGED_COMMANDS = {"install", "installpkg", "remove", "upgrade", "upgradepkg", "rollback"}
+_PRIVILEGED_COMMANDS = {
+    "install",
+    "installpkg",
+    "remove",
+    "removepkg",
+    "upgrade",
+    "upgradepkg",
+    "rollback",
+}
 _STATE_COMMANDS = {
     "autoremove",
     "bootstrap",
@@ -7103,6 +7111,7 @@ def main(argv=None):
             _initialize_cli_state()
         if cmd in _PRIVILEGED_COMMANDS:
             with operation_phase(privileged=True):
+                require_root(cmd)
                 args.func(args)
         else:
             args.func(args)

--- a/tests/test_first_run_setup.py
+++ b/tests/test_first_run_setup.py
@@ -431,3 +431,44 @@ def test_gather_metadata_prefers_build_info(monkeypatch, tmp_path):
     assert metadata["version"] == "9.9.9"
     assert metadata["build_date"] == "2024-06-01T00:00:00Z"
     assert metadata["build"] == "release"
+
+
+def test_privileged_cli_requires_root_before_install_planning(monkeypatch, tmp_path):
+    import importlib
+
+    app = importlib.import_module("lpm.app")
+    conf_path = tmp_path / "lpm.conf"
+    conf_path.write_text("ARCH=x86_64\n", encoding="utf-8")
+    events = []
+
+    def fake_operation_phase(*, privileged=True):
+        assert privileged is True
+        return _recording_operation_phase(events)
+
+    def fake_initialize_cli_state():
+        events.append(("state", None, None))
+
+    def fake_require_root(cmd):
+        events.append(("gate", cmd, None))
+        raise SystemExit(1)
+
+    def fake_cmd_install(_args):
+        events.append(("install", None, None))
+
+    monkeypatch.setattr(app, "CONF_FILE", conf_path, raising=False)
+    monkeypatch.setattr(lpm, "CONF_FILE", conf_path, raising=False)
+    monkeypatch.setattr(app, "operation_phase", fake_operation_phase)
+    monkeypatch.setattr(app, "_initialize_cli_state", fake_initialize_cli_state)
+    monkeypatch.setattr(app, "require_root", fake_require_root)
+    monkeypatch.setattr(app, "cmd_install", fake_cmd_install)
+
+    with pytest.raises(SystemExit) as exc_info:
+        lpm.main(["install", "demo"])
+
+    assert exc_info.value.code == 1
+    assert events == [
+        ("state", None, None),
+        ("enter", True, None),
+        ("gate", "install", None),
+        ("exit", True, None),
+    ]


### PR DESCRIPTION
### Motivation

- Ensure CLI-level privilege checks run as a hard gate for potentially destructive package operations so they occur before resolver planning, snapshot creation, package extraction, DB writes, hook transactions, service-file handling, mount/chroot work, or any package side-effect.

### Description

- Import and use the existing `require_root` helper in `src/lpm/app.py` and keep the internal `_require_privileged_default_root()` function for API/default-root safety.
- Add `removepkg` to the `_PRIVILEGED_COMMANDS` set so local-package removal CLI paths are covered alongside `install`/`installpkg`/`remove`/`upgrade` commands.
- In `main(argv=None)` call `require_root(cmd)` inside the privileged `operation_phase` after first-run/state initialization and before dispatching to `args.func(args)`, ensuring the gate runs prior to any package operation planning or side effects.
- Add a regression test `test_privileged_cli_requires_root_before_install_planning` to `tests/test_first_run_setup.py` that validates the gate runs after state init and before install planning.

### Testing

- Ran `python3 -m pytest tests/test_first_run_setup.py tests/test_privileges.py` and both test modules passed.
- Ran `python3 -m py_compile src/lpm/app.py tests/test_first_run_setup.py` which succeeded.
- Ran full `python3 -m pytest`; collection failed due to an unrelated, pre-existing syntax error in `tests/test_installpkg_symlink.py` (not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a190f0e32b0832784c329efa860124d)