### PR TITLE
Fix buildchroot chrooted execution

### DIFF
--- a/src/lpm/chroot_helpers.py
+++ b/src/lpm/chroot_helpers.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 from typing import Any
 
-from lpm.bootstrap import _safe_target, generate_lpm_root_install_command
+from lpm.bootstrap import _safe_target, generate_chroot_command, generate_lpm_root_install_command
 from lpm.chroot import ChrootMountState, mount_chroot_api, umount_chroot_api
 
 
@@ -64,6 +64,65 @@ def _run_root_install(target_root: Path, packages: list[str], *, dry_run: bool =
     else:
         result["failed"] = packages
     return result
+
+
+def _bind_mount(source: Path, target: Path) -> None:
+    target.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["mount", "--bind", str(source), str(target)], check=True)
+
+
+def _umount_path(target: Path) -> None:
+    subprocess.run(["umount", str(target)], check=True)
+
+
+def _chroot_absolute(path: Path) -> str:
+    return "/" + str(path).lstrip("/")
+
+
+def _manifest_script_in_chroot(script: Path, source: Path, source_mount_rel: Path) -> str:
+    try:
+        rel = script.resolve().relative_to(source.resolve())
+    except ValueError as exc:
+        raise ValueError(f"manifest script is outside build source: {script}") from exc
+    return _chroot_absolute(source_mount_rel / rel)
+
+
+def _host_path_from_chroot_path(chroot_path: str, root: Path, cache_dir: Path, cache_mount_rel: Path) -> Path:
+    path = Path(chroot_path)
+    cache_mount = Path(_chroot_absolute(cache_mount_rel))
+    try:
+        rel = path.relative_to(cache_mount)
+    except ValueError:
+        return root / str(path).lstrip("/")
+    return cache_dir / rel
+
+
+def _run_chroot_lpmbuild(root: Path, script_in_chroot: str, outdir_in_chroot: str) -> dict[str, Any]:
+    code = (
+        "import json, sys\n"
+        "from pathlib import Path\n"
+        "from lpm import app as lpm_app\n"
+        "blob, _elapsed, _size, splits = lpm_app.run_lpmbuild("
+        "Path(sys.argv[1]), outdir=Path(sys.argv[2]), prompt_install=False, build_deps=True"
+        ")\n"
+        "print('LPM_BUILDCHROOT_RESULT=' + json.dumps({"
+        "'blob': str(blob), 'splits': [str(path) for path, _meta in splits]"
+        "}))\n"
+    )
+    cmd = generate_chroot_command(root, ["python3", "-c", code, script_in_chroot, outdir_in_chroot])
+    proc = subprocess.run(cmd, check=False, text=True, capture_output=True)
+    if proc.stdout:
+        print(proc.stdout, end="")
+    if proc.stderr:
+        print(proc.stderr, end="")
+    if proc.returncode != 0:
+        raise subprocess.CalledProcessError(proc.returncode, cmd, output=proc.stdout, stderr=proc.stderr)
+
+    marker = "LPM_BUILDCHROOT_RESULT="
+    for line in reversed((proc.stdout or "").splitlines()):
+        if line.startswith(marker):
+            return json.loads(line[len(marker):])
+    raise RuntimeError("chroot lpmbuild did not report build artifacts")
 
 
 def run_bootstrap_chroot(args: Any) -> int:
@@ -214,8 +273,6 @@ def run_buildchroot(args: Any) -> int:
         _echo("[buildchroot] dry-run enabled; no filesystem changes", verbose=verbose)
         return 0
 
-    from lpm import app as lpm_app
-
     manifest_path = output_dir / "build-manifest.json"
     if manifest_path.exists():
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -237,10 +294,40 @@ def run_buildchroot(args: Any) -> int:
 
     staged_repo = output_dir / "repo"
     staged_repo.mkdir(parents=True, exist_ok=True)
-    for idx, pkg in enumerate(packages, start=1):
-        name = str(pkg.get("name", ""))
-        script = Path(str(pkg.get("script", "")))
-        print(f"[buildchroot {idx}/{len(packages)}] {name}")
-        blob, _elapsed, _size, _splits = lpm_app.run_lpmbuild(script, outdir=cache_dir, prompt_install=False, build_deps=True)
-        shutil.copy2(blob, staged_repo / Path(blob).name)
-    return 0
+
+    source_mount_rel = Path("tmp/lpm-buildchroot/source")
+    cache_mount_rel = Path("tmp/lpm-buildchroot/cache")
+    source_mount = root / source_mount_rel
+    cache_mount = root / cache_mount_rel
+    cache_in_chroot = _chroot_absolute(cache_mount_rel)
+
+    mount_state = ChrootMountState(mounted=[])
+    bind_mounts: list[Path] = []
+    try:
+        _bind_mount(source.resolve(), source_mount)
+        bind_mounts.append(source_mount)
+        _bind_mount(cache_dir.resolve(), cache_mount)
+        bind_mounts.append(cache_mount)
+        mount_state = mount_chroot_api(root, mount_state)
+
+        for idx, pkg in enumerate(packages, start=1):
+            name = str(pkg.get("name", ""))
+            script = Path(str(pkg.get("script", "")))
+            script_in_chroot = _manifest_script_in_chroot(script, source, source_mount_rel)
+            print(f"[buildchroot {idx}/{len(packages)}] {name}")
+            result = _run_chroot_lpmbuild(root, script_in_chroot, cache_in_chroot)
+            built_paths = [str(result.get("blob", "")), *[str(p) for p in result.get("splits", [])]]
+            for built in built_paths:
+                if not built:
+                    continue
+                host_path = _host_path_from_chroot_path(built, root, cache_dir, cache_mount_rel)
+                if not host_path.exists():
+                    raise FileNotFoundError(f"built artifact not found outside chroot: {host_path}")
+                shutil.copy2(host_path, staged_repo / host_path.name)
+        return 0
+    finally:
+        try:
+            umount_chroot_api(root, mount_state)
+        finally:
+            for mountpoint in reversed(bind_mounts):
+                _umount_path(mountpoint)

--- a/tests/test_buildgen_buildchroot.py
+++ b/tests/test_buildgen_buildchroot.py
@@ -79,3 +79,70 @@ def test_buildchroot_missing_script_fails(tmp_path: Path) -> None:
     )
     with pytest.raises(ValueError, match="Missing .lpmbuild scripts for build targets"):
         chroot_helpers.run_buildchroot(args)
+
+
+def test_buildchroot_executes_build_inside_requested_chroot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = tmp_path / "packages"
+    script = source / "demo" / "demo.lpmbuild"
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_text("# stub\n", encoding="utf-8")
+
+    output = tmp_path / "out"
+    output.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "package_order": ["demo"],
+        "packages": [{"name": "demo", "script": str(script), "depends": []}],
+    }
+    (output / "build-manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    root = tmp_path / "root"
+    cache = tmp_path / "cache"
+    built = cache / "demo.lpm"
+    commands: list[list[str]] = []
+    mounted_api: list[Path] = []
+    unmounted_api: list[Path] = []
+
+    def fake_mount_api(target: Path, state: chroot_helpers.ChrootMountState) -> chroot_helpers.ChrootMountState:
+        mounted_api.append(Path(target))
+        state.mark_mounted("proc")
+        return state
+
+    def fake_umount_api(target: Path, state: chroot_helpers.ChrootMountState) -> chroot_helpers.ChrootMountState:
+        unmounted_api.append(Path(target))
+        state.mounted.clear()
+        return state
+
+    def fake_run(cmd, check=False, text=False, capture_output=False):
+        cmd = [str(part) for part in cmd]
+        commands.append(cmd)
+        if cmd[:2] == ["mount", "--bind"]:
+            return chroot_helpers.subprocess.CompletedProcess(cmd, 0)
+        if cmd[0] == "umount":
+            return chroot_helpers.subprocess.CompletedProcess(cmd, 0)
+        if cmd[:2] == ["chroot", str(root)]:
+            assert cmd[2:5] == ["python3", "-c", cmd[4]]
+            assert cmd[-2] == "/tmp/lpm-buildchroot/source/demo/demo.lpmbuild"
+            assert cmd[-1] == "/tmp/lpm-buildchroot/cache"
+            built.write_text("package", encoding="utf-8")
+            stdout = 'LPM_BUILDCHROOT_RESULT={"blob":"/tmp/lpm-buildchroot/cache/demo.lpm","splits":[]}\n'
+            return chroot_helpers.subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(chroot_helpers, "mount_chroot_api", fake_mount_api)
+    monkeypatch.setattr(chroot_helpers, "umount_chroot_api", fake_umount_api)
+    monkeypatch.setattr(chroot_helpers.subprocess, "run", fake_run)
+
+    args = Namespace(
+        root=str(root),
+        source=str(source),
+        cache_dir=str(cache),
+        output_dir=str(output),
+        dry_run=False,
+        verbose=False,
+    )
+
+    assert chroot_helpers.run_buildchroot(args) == 0
+    assert mounted_api == [root]
+    assert unmounted_api == [root]
+    assert (output / "repo" / "demo.lpm").read_text(encoding="utf-8") == "package"
+    assert [cmd[0] for cmd in commands] == ["mount", "mount", "chroot", "umount", "umount"]


### PR DESCRIPTION
### Motivation
- `buildchroot` previously invoked `run_lpmbuild` in the host environment, which breaks isolation and can leak host-installed packages into dependency resolution. 
- Builds must execute inside the requested target root so dependency resolution and build scripts run with the intended root-scoped environment. 

### Description
- Added chroot-aware helpers and switched to `chroot <root> python3 -c ...` to run `lpm_app.run_lpmbuild` inside the target root via `generate_chroot_command`. 
- Bind-mount the requested `source` tree and `cache` directory into the chroot under `tmp/lpm-buildchroot/`, translate chroot-reported artifact paths back to host paths, and stage built artifacts into `output_dir/repo`. 
- Implemented `_bind_mount`, `_umount_path`, `_chroot_absolute`, `_manifest_script_in_chroot`, `_host_path_from_chroot_path`, and `_run_chroot_lpmbuild`, and made `run_buildchroot` perform mount lifecycle management and robust cleanup. 
- Added a regression test `test_buildchroot_executes_build_inside_requested_chroot` that verifies chroot API mounting, `chroot` invocation with chroot-local paths, and artifact staging. 

### Testing
- Compiled the modified module with `python -m compileall -q src/lpm/chroot_helpers.py` and it succeeded. 
- Ran `PYTHONPATH=src pytest -q tests/test_buildgen_buildchroot.py` and the test suite for buildgen/buildchroot passed (`4 passed`). 
- Ran `PYTHONPATH=src pytest -q tests/test_chroot.py tests/test_buildgen_buildchroot.py` and the combined chroot-related tests passed (`tests/test_chroot.py` + buildgen tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1985b98d108327a98f974f3e6f18b4)