### PR TITLE
Initialize LPM state for upgrade commands

### DIFF
--- a/src/lpm/app.py
+++ b/src/lpm/app.py
@@ -4926,6 +4926,8 @@ _STATE_COMMANDS = {
     "search",
     "snapshots",
     "splitpkg",
+    "upgrade",
+    "upgradepkg",
     "verify",
 }
 

--- a/tests/test_first_run_setup.py
+++ b/tests/test_first_run_setup.py
@@ -317,6 +317,45 @@ def test_missing_state_non_root_reports_actionable_setup_message(monkeypatch, tm
     assert "Traceback" not in captured.err
 
 
+@pytest.mark.parametrize("command", ["upgrade", "upgradepkg"])
+def test_upgrade_commands_initialize_existing_config_state(command, monkeypatch, tmp_path):
+    import importlib
+
+    app = importlib.import_module("lpm.app")
+    conf_path = tmp_path / "etc" / "lpm" / "lpm.conf"
+    conf_path.parent.mkdir(parents=True)
+    conf_path.write_text("ARCH=x86_64\n", encoding="utf-8")
+    events = []
+
+    def fake_operation_phase(*, privileged=True):
+        assert privileged is True
+        return _recording_operation_phase(events)
+
+    def fake_initialize_state():
+        events.append(("initialize_state", None, None))
+
+    def fake_upgrade(args):
+        events.append(("command", args.cmd, None))
+
+    monkeypatch.setattr(app, "CONF_FILE", conf_path, raising=False)
+    monkeypatch.setattr(lpm, "CONF_FILE", conf_path, raising=False)
+    monkeypatch.setattr(app, "operation_phase", fake_operation_phase)
+    monkeypatch.setattr(app, "initialize_state", fake_initialize_state)
+    monkeypatch.setattr(lpm, "initialize_state", fake_initialize_state)
+    monkeypatch.setattr(app, "cmd_upgrade", fake_upgrade)
+
+    lpm.main([command])
+
+    assert events == [
+        ("enter", True, None),
+        ("initialize_state", None, None),
+        ("exit", True, None),
+        ("enter", True, None),
+        ("command", command, None),
+        ("exit", True, None),
+    ]
+
+
 def test_setup_command_runs_wizard_and_writes_config(monkeypatch, tmp_path):
     import importlib
 


### PR DESCRIPTION
### Motivation
- Fix a bug where `upgrade`/`upgradepkg` skipped CLI state initialization and could hit `FileNotFoundError` (e.g., missing `PIN_FILE`) when a config existed but the state tree was not created.

### Description
- Add `"upgrade"` and `"upgradepkg"` to the `_STATE_COMMANDS` set so `_initialize_cli_state()` runs for these commands before dispatch in `src/lpm/app.py`.
- Add a parameterized test `test_upgrade_commands_initialize_existing_config_state` in `tests/test_first_run_setup.py` to assert state initialization occurs for both `upgrade` and `upgradepkg` before the command handler runs.

### Testing
- Ran `pytest -q tests/test_first_run_setup.py` and the suite passed (`12 passed`).
- Verified `python -m py_compile src/lpm/app.py tests/test_first_run_setup.py` succeeded with no syntax errors.
- Ran `git diff --check` (no whitespace/errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1988354a9483279a38577827edce00)