### PR TITLE
Support direct .lpmbuild sources in buildgen

### DIFF
--- a/src/lpm/chroot_helpers.py
+++ b/src/lpm/chroot_helpers.py
@@ -129,7 +129,13 @@ def run_buildgen(args: Any) -> int:
 
     from lpm import app as lpm_app
 
-    scripts = sorted(source.glob("*/**/*.lpmbuild")) if source.is_dir() else []
+    if source.is_file() and source.suffix == ".lpmbuild":
+        scripts = [source]
+    elif source.is_dir():
+        scripts = sorted(source.rglob("*.lpmbuild"))
+    else:
+        raise ValueError(f"no .lpmbuild scripts found under: {source}")
+
     if not scripts:
         raise ValueError(f"no .lpmbuild scripts found under: {source}")
 

--- a/tests/test_buildgen_buildchroot.py
+++ b/tests/test_buildgen_buildchroot.py
@@ -39,6 +39,77 @@ def test_buildgen_manifest_is_deterministic(tmp_path: Path, monkeypatch: pytest.
     assert m1 == m2
 
 
+def test_buildgen_accepts_direct_lpmbuild_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    script = tmp_path / "demo.lpmbuild"
+    script.write_text("# demo\n", encoding="utf-8")
+
+    from lpm import app as lpm_app
+
+    def fake_capture(path: Path):
+        assert path == script
+        return {"NAME": "demo", "VERSION": "1"}, {"REQUIRES": []}, {}
+
+    monkeypatch.setattr(lpm_app, "_capture_lpmbuild_metadata", fake_capture)
+
+    out = tmp_path / "out"
+    args = Namespace(root=str(tmp_path / "root"), source=str(script), output_dir=str(out), dry_run=False, verbose=False)
+
+    assert chroot_helpers.run_buildgen(args) == 0
+
+    manifest = json.loads((out / "build-manifest.json").read_text(encoding="utf-8"))
+    assert manifest["source"] == str(script)
+    assert manifest["package_order"] == ["demo"]
+    assert manifest["packages"][0]["script"] == str(script)
+
+
+def test_buildgen_finds_lpmbuild_directly_in_source_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    src = tmp_path / "packages"
+    src.mkdir()
+    script = src / "demo.lpmbuild"
+    script.write_text("# demo\n", encoding="utf-8")
+
+    from lpm import app as lpm_app
+
+    def fake_capture(path: Path):
+        assert path == script
+        return {"NAME": "demo", "VERSION": "1"}, {"REQUIRES": []}, {}
+
+    monkeypatch.setattr(lpm_app, "_capture_lpmbuild_metadata", fake_capture)
+
+    out = tmp_path / "out"
+    args = Namespace(root=str(tmp_path / "root"), source=str(src), output_dir=str(out), dry_run=False, verbose=False)
+
+    assert chroot_helpers.run_buildgen(args) == 0
+
+    manifest = json.loads((out / "build-manifest.json").read_text(encoding="utf-8"))
+    assert manifest["package_order"] == ["demo"]
+    assert manifest["packages"][0]["script"] == str(script)
+
+
+def test_buildgen_finds_nested_maintainer_mode_layouts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    src = tmp_path / "packages"
+    script = src / "lpmbuilds" / "demo" / "1" / "demo.lpmbuild"
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_text("# demo\n", encoding="utf-8")
+
+    from lpm import app as lpm_app
+
+    def fake_capture(path: Path):
+        assert path == script
+        return {"NAME": "demo", "VERSION": "1"}, {"REQUIRES": []}, {}
+
+    monkeypatch.setattr(lpm_app, "_capture_lpmbuild_metadata", fake_capture)
+
+    out = tmp_path / "out"
+    args = Namespace(root=str(tmp_path / "root"), source=str(src), output_dir=str(out), dry_run=False, verbose=False)
+
+    assert chroot_helpers.run_buildgen(args) == 0
+
+    manifest = json.loads((out / "build-manifest.json").read_text(encoding="utf-8"))
+    assert manifest["package_order"] == ["demo"]
+    assert manifest["packages"][0]["script"] == str(script)
+
+
 def test_buildgen_cycle_detection(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     src = tmp_path / "packages"
     for name in ("a", "b"):


### PR DESCRIPTION
### Motivation
- Allow `run_buildgen` to accept a direct `.lpmbuild` file as the `source` so callers can target a single script file. 
- Ensure directory discovery includes files placed at the source root and nested maintainer-mode layouts (e.g. `lpmbuilds/pkg/version/pkg.lpmbuild`).

### Description
- Replace the previous `source.glob("*/**/*.lpmbuild")` logic in `run_buildgen` with a branch that returns `[source]` when `source.is_file()` and `source.suffix == ".lpmbuild"`, uses `sorted(source.rglob("*.lpmbuild"))` when `source.is_dir()`, and preserves the existing error for other cases. 
- Preserve the existing empty-results check and the `no .lpmbuild scripts found under: ...` error when no scripts are discovered. 
- Add three tests to `tests/test_buildgen_buildchroot.py` covering a direct `.lpmbuild` path, a `.lpmbuild` placed directly inside the source directory, and a nested maintainer-mode layout `lpmbuilds/<pkg>/<version>/<pkg>.lpmbuild`.

### Testing
- Ran `pytest tests/test_buildgen_buildchroot.py` and all tests passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a45f6ea848327b990dbe5320a28a8)