### PR TITLE
Record chroot setup in build manifest

### DIFF
--- a/src/lpm/chroot_helpers.py
+++ b/src/lpm/chroot_helpers.py
@@ -19,6 +19,11 @@ def _normalize_root(root: str | None) -> Path:
     return Path(root or "/")
 
 
+def _stable_path(path: str | Path) -> str:
+    """Serialize paths consistently for deterministic JSON manifests."""
+    return Path(path).as_posix()
+
+
 def _read_manifest_packages(manifest: str | None) -> list[str]:
     if not manifest:
         return []
@@ -160,11 +165,22 @@ def run_buildgen(args: Any) -> int:
             token = token.split(">=")[0].split("<=")[0].split("=")[0].split("<")[0].split(">")[0]
             if token:
                 dep_names.add(token)
+        version = str(scal.get("VERSION") or scal.get("version") or "")
+        release = str(scal.get("RELEASE") or scal.get("release") or "1")
+        arch = str(scal.get("ARCH") or scal.get("arch") or "noarch")
+        repo_dir = output_dir / "repo"
+        planned_artifact = repo_dir / f"{name}-{version}-{release}.{arch}.zst"
         meta_by_pkg[name] = {
             "name": name,
-            "version": str(scal.get("VERSION") or scal.get("version") or ""),
-            "script": str(script),
+            "version": version,
+            "release": release,
+            "arch": arch,
+            "script": _stable_path(script),
             "depends": sorted(dep_names),
+            "build_output_dir": _stable_path(output_dir / "build" / name),
+            "repo_dir": _stable_path(repo_dir),
+            "planned_artifact": _stable_path(planned_artifact),
+            "planned_artifacts": [_stable_path(planned_artifact)],
         }
         deps_by_pkg[name] = set(dep_names)
 
@@ -194,10 +210,25 @@ def run_buildgen(args: Any) -> int:
         raise ValueError("Cycle detected in buildgen dependency graph. Cycle groups: " + ", ".join(remaining))
 
     output_dir.mkdir(parents=True, exist_ok=True)
+    repo_dir = output_dir / "repo"
+    bootstrap_packages = sorted(
+        str(pkg)
+        for pkg in (getattr(args, "bootstrap_packages", None) or getattr(args, "packages", []) or [])
+    )
     manifest = {
-        "source": str(source),
+        "root": _stable_path(root),
+        "source": _stable_path(source),
+        "output_dir": _stable_path(output_dir),
+        "repo_dir": _stable_path(repo_dir),
+        "bootstrap_packages": bootstrap_packages,
         "package_order": order,
         "packages": [meta_by_pkg[n] for n in order],
+        "chroot_setup": {
+            "root": _stable_path(root),
+            "output_dir": _stable_path(output_dir),
+            "repo_dir": _stable_path(repo_dir),
+            "bootstrap_packages": bootstrap_packages,
+        },
     }
     manifest_path = output_dir / "build-manifest.json"
     manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -226,11 +257,27 @@ def run_buildchroot(args: Any) -> int:
     if manifest_path.exists():
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     else:
-        tmp_args = type("BuildGenArgs", (), {
-            "root": str(root), "source": str(source), "output_dir": str(output_dir), "dry_run": False, "verbose": verbose
-        })()
+        tmp_args = type(
+            "BuildGenArgs",
+            (),
+            {
+                "root": str(root),
+                "source": str(source),
+                "output_dir": str(output_dir),
+                "dry_run": False,
+                "verbose": verbose,
+            },
+        )()
         run_buildgen(tmp_args)
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    setup = manifest.get("chroot_setup", {}) if isinstance(manifest.get("chroot_setup", {}), dict) else {}
+    root = Path(str(manifest.get("root") or setup.get("root") or root))
+    output_dir = Path(str(manifest.get("output_dir") or setup.get("output_dir") or output_dir))
+    staged_repo = Path(str(manifest.get("repo_dir") or setup.get("repo_dir") or output_dir / "repo"))
+    bootstrap_packages = [
+        str(pkg) for pkg in (manifest.get("bootstrap_packages") or setup.get("bootstrap_packages") or [])
+    ]
 
     packages = manifest.get("packages", []) or []
     missing = [p.get("script") for p in packages if not Path(str(p.get("script", ""))).exists()]
@@ -241,14 +288,22 @@ def run_buildchroot(args: Any) -> int:
     cache_dir.mkdir(parents=True, exist_ok=True)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    staged_repo = output_dir / "repo"
     staged_repo.mkdir(parents=True, exist_ok=True)
+    if bootstrap_packages:
+        bootstrap_result = _run_root_install(root, bootstrap_packages)
+        print(json.dumps(bootstrap_result, indent=2, sort_keys=True))
+        bootstrap_rc = int(bootstrap_result.get("returncode", 0))
+        if bootstrap_rc != 0:
+            return bootstrap_rc
+
     built_package_names: list[str] = []
     for idx, pkg in enumerate(packages, start=1):
         name = str(pkg.get("name", ""))
         script = Path(str(pkg.get("script", "")))
         print(f"[buildchroot {idx}/{len(packages)}] {name}")
-        blob, _elapsed, _size, _splits = lpm_app.run_lpmbuild(script, outdir=cache_dir, prompt_install=False, build_deps=True)
+        blob, _elapsed, _size, _splits = lpm_app.run_lpmbuild(
+            script, outdir=cache_dir, prompt_install=False, build_deps=True
+        )
         shutil.copy2(blob, staged_repo / Path(blob).name)
         if name:
             built_package_names.append(name)

--- a/tests/test_buildgen_buildchroot.py
+++ b/tests/test_buildgen_buildchroot.py
@@ -33,10 +33,65 @@ def test_buildgen_manifest_is_deterministic(tmp_path: Path, monkeypatch: pytest.
     assert chroot_helpers.run_buildgen(args1) == 0
     assert chroot_helpers.run_buildgen(args2) == 0
 
-    m1 = json.loads((out1 / "build-manifest.json").read_text(encoding="utf-8"))
-    m2 = json.loads((out2 / "build-manifest.json").read_text(encoding="utf-8"))
+    raw1 = (out1 / "build-manifest.json").read_text(encoding="utf-8")
+    raw2 = (out2 / "build-manifest.json").read_text(encoding="utf-8")
+    m1 = json.loads(raw1)
+    m2 = json.loads(raw2)
     assert m1["package_order"] == ["b", "a"]
-    assert m1 == m2
+
+    def normalize_package_paths(packages: list[dict[str, object]], output_dir: Path) -> list[dict[str, object]]:
+        normalized = []
+        for pkg in packages:
+            item = dict(pkg)
+            for key in ("build_output_dir", "repo_dir", "planned_artifact"):
+                item[key] = str(item[key]).replace(output_dir.as_posix(), "<output>")
+            item["planned_artifacts"] = [
+                str(path).replace(output_dir.as_posix(), "<output>")
+                for path in item["planned_artifacts"]
+            ]
+            normalized.append(item)
+        return normalized
+
+    assert normalize_package_paths(m1["packages"], out1) == normalize_package_paths(m2["packages"], out2)
+    assert raw1 == json.dumps(m1, indent=2, sort_keys=True) + "\n"
+    assert raw2 == json.dumps(m2, indent=2, sort_keys=True) + "\n"
+
+
+def test_buildgen_manifest_records_chroot_setup_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    src = tmp_path / "packages"
+    script = src / "demo.lpmbuild"
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_text("# demo\n", encoding="utf-8")
+
+    from lpm import app as lpm_app
+
+    def fake_capture(path: Path):
+        assert path == script
+        return {"NAME": "demo", "VERSION": "2", "RELEASE": "3", "ARCH": "x86_64"}, {"REQUIRES": []}, {}
+
+    monkeypatch.setattr(lpm_app, "_capture_lpmbuild_metadata", fake_capture)
+
+    root = tmp_path / "target-root"
+    out = tmp_path / "out"
+    args = Namespace(root=str(root), source=str(src), output_dir=str(out), dry_run=False, verbose=False)
+
+    assert chroot_helpers.run_buildgen(args) == 0
+
+    manifest = json.loads((out / "build-manifest.json").read_text(encoding="utf-8"))
+    assert manifest["root"] == root.as_posix()
+    assert manifest["output_dir"] == out.as_posix()
+    assert manifest["repo_dir"] == (out / "repo").as_posix()
+    assert manifest["bootstrap_packages"] == []
+    assert manifest["chroot_setup"] == {
+        "bootstrap_packages": [],
+        "output_dir": out.as_posix(),
+        "repo_dir": (out / "repo").as_posix(),
+        "root": root.as_posix(),
+    }
+    assert manifest["packages"][0]["build_output_dir"] == (out / "build" / "demo").as_posix()
+    assert manifest["packages"][0]["repo_dir"] == (out / "repo").as_posix()
+    assert manifest["packages"][0]["planned_artifact"] == (out / "repo" / "demo-2-3.x86_64.zst").as_posix()
+    assert manifest["packages"][0]["planned_artifacts"] == [(out / "repo" / "demo-2-3.x86_64.zst").as_posix()]
 
 
 def test_buildgen_accepts_direct_lpmbuild_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -125,7 +180,13 @@ def test_buildgen_cycle_detection(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
         return {"NAME": "b", "VERSION": "1"}, {"REQUIRES": ["a"]}, {}
 
     monkeypatch.setattr(lpm_app, "_capture_lpmbuild_metadata", fake_capture)
-    args = Namespace(root=str(tmp_path / "root"), source=str(src), output_dir=str(tmp_path / "out"), dry_run=False, verbose=False)
+    args = Namespace(
+        root=str(tmp_path / "root"),
+        source=str(src),
+        output_dir=str(tmp_path / "out"),
+        dry_run=False,
+        verbose=False,
+    )
 
     with pytest.raises(ValueError, match="Cycle detected in buildgen dependency graph"):
         chroot_helpers.run_buildgen(args)
@@ -150,6 +211,60 @@ def test_buildchroot_missing_script_fails(tmp_path: Path) -> None:
     )
     with pytest.raises(ValueError, match="Missing .lpmbuild scripts for build targets"):
         chroot_helpers.run_buildchroot(args)
+
+
+def test_buildchroot_uses_manifest_chroot_setup_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    script = tmp_path / "packages" / "demo" / "demo.lpmbuild"
+    script.parent.mkdir(parents=True, exist_ok=True)
+    script.write_text("# demo\n", encoding="utf-8")
+
+    cli_out = tmp_path / "cli-out"
+    cli_out.mkdir(parents=True, exist_ok=True)
+    manifest_root = tmp_path / "manifest-root"
+    manifest_out = tmp_path / "manifest-out"
+    manifest_repo = tmp_path / "manifest-repo"
+    manifest = {
+        "root": manifest_root.as_posix(),
+        "output_dir": manifest_out.as_posix(),
+        "repo_dir": manifest_repo.as_posix(),
+        "bootstrap_packages": ["base", "toolchain"],
+        "package_order": ["demo"],
+        "packages": [{"name": "demo", "script": script.as_posix(), "depends": []}],
+    }
+    (cli_out / "build-manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    built_blob = tmp_path / "cache" / "demo-1-any.zst"
+
+    from lpm import app as lpm_app
+
+    def fake_run_lpmbuild(*_args, **_kwargs):
+        built_blob.parent.mkdir(parents=True, exist_ok=True)
+        built_blob.write_text("blob", encoding="utf-8")
+        return built_blob, 0.0, built_blob.stat().st_size, []
+
+    install_calls: list[tuple[Path, list[str]]] = []
+
+    def fake_run_root_install(root: Path, packages: list[str], *, dry_run: bool = False):
+        install_calls.append((root, list(packages)))
+        return {"returncode": 0, "dry_run": dry_run}
+
+    monkeypatch.setattr(lpm_app, "run_lpmbuild", fake_run_lpmbuild)
+    monkeypatch.setattr(chroot_helpers, "_run_root_install", fake_run_root_install)
+
+    args = Namespace(
+        root=str(tmp_path / "cli-root"),
+        source=str(tmp_path / "packages"),
+        cache_dir=str(tmp_path / "cache"),
+        output_dir=str(cli_out),
+        dry_run=False,
+        verbose=False,
+    )
+
+    rc = chroot_helpers.run_buildchroot(args)
+    assert rc == 0
+    assert install_calls == [(manifest_root, ["base", "toolchain"]), (manifest_root, ["demo"])]
+    assert (manifest_repo / built_blob.name).exists()
+    assert not (cli_out / "repo" / built_blob.name).exists()
 
 
 def test_buildchroot_installs_built_packages(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
### Motivation
- Make build manifests self-contained by recording chroot setup information (root, repo/output paths and bootstrap packages) so downstream tools can drive `buildchroot` from the manifest instead of re-deriving assumptions from CLI flags.
- Record per-package planned artifact locations and build output paths so staged artifacts and planned repo layout are explicit in the manifest.
- Ensure manifests are deterministic and stable across runs by normalizing paths and using stable JSON key ordering.

### Description
- Add `_stable_path()` helper to serialize paths consistently for deterministic manifests and use it when recording manifest fields.
- Extend `run_buildgen()` to include chroot setup metadata in the manifest: `root`, `source`, `output_dir`, `repo_dir`, `bootstrap_packages`, and `chroot_setup` object, and per-package fields such as `build_output_dir`, `repo_dir`, `planned_artifact`, and `planned_artifacts`; include `release` and `arch` in package metadata.
- Write the manifest with stable serialization using `json.dumps(..., sort_keys=True)` and normalized path strings so ordering and path format are deterministic.
- Update `run_buildchroot()` to read `root`, `output_dir`, `repo_dir`, and `bootstrap_packages` from the manifest (or its `chroot_setup`) and to honor those values when staging artifacts and bootstrapping the chroot, rather than reconstructing them only from CLI args.
- Install any `bootstrap_packages` recorded in the manifest before building package artifacts and staging them to the manifest `repo_dir`.
- Add tests to `tests/test_buildgen_buildchroot.py` to assert deterministic manifest output and that the manifest records chroot/setup paths and per-package planned artifact locations, and that `run_buildchroot()` uses manifest-provided root/repo/bootstrap settings.

### Testing
- Ran `pytest tests/test_buildgen_buildchroot.py -q` and observed all tests pass (`9 passed`).
- Verified manifest JSON is stable and produced with `sort_keys=True` and normalized path serialization via `_stable_path()`.
- Confirmed new `buildchroot` behavior installs manifest `bootstrap_packages` and stages built blobs into the manifest `repo_dir` as asserted by the new tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a4a49234883278dd8aa77fd99c1d4)