### PR TITLE
Resolve virtual/provided dependencies in buildgen and add test

### DIFF
--- a/src/lpm/chroot_helpers.py
+++ b/src/lpm/chroot_helpers.py
@@ -250,10 +250,32 @@ def run_buildgen(args: Any) -> int:
     if not scripts:
         raise ValueError(f"no .lpmbuild scripts found under: {source}")
 
+    def _metadata_name(raw: Any) -> str:
+        try:
+            expr = lpm_app.parse_dep_expr(str(raw))
+            if getattr(expr, "kind", None) == "atom" and getattr(expr, "atom", None):
+                parsed_name = str(expr.atom.name).strip()
+                if parsed_name:
+                    return parsed_name
+        except Exception:
+            pass
+        token = str(raw).strip().split()[0] if str(raw).strip() else ""
+        token = (
+            token.split(">=")[0]
+            .split("<=")[0]
+            .split("==")[0]
+            .split("=")[0]
+            .split("<")[0]
+            .split(">")[0]
+        )
+        return token.strip()
+
     meta_by_pkg: dict[str, dict[str, Any]] = {}
     deps_by_pkg: dict[str, set[str]] = {}
+    raw_provides_by_pkg: dict[str, set[str]] = {}
+    mapped_provides_by_pkg: dict[str, set[str]] = {}
     for script in scripts:
-        scal, arr, _maps = lpm_app._capture_lpmbuild_metadata(script)
+        scal, arr, maps = lpm_app._capture_lpmbuild_metadata(script)
         name = str(scal.get("NAME") or scal.get("name") or "").strip()
         if not name:
             continue
@@ -262,21 +284,30 @@ def run_buildgen(args: Any) -> int:
             dep_fields.extend([str(x) for x in (arr.get(key) or []) if x])
         dep_names: set[str] = set()
         for raw in dep_fields:
-            try:
-                dep_names.add(lpm_app.parse_dep_expr(raw).name)
-                continue
-            except Exception:
-                pass
-            token = str(raw).strip().split()[0] if str(raw).strip() else ""
-            token = (
-                token.split(">=")[0]
-                .split("<=")[0]
-                .split("=")[0]
-                .split("<")[0]
-                .split(">")[0]
-            )
+            token = _metadata_name(raw)
             if token:
                 dep_names.add(token)
+
+        provides: set[str] = set()
+        for raw in arr.get("PROVIDES") or arr.get("provides") or []:
+            token = _metadata_name(raw)
+            if token:
+                provides.add(token)
+        raw_provides_by_pkg[name] = set(provides)
+
+        meta_provides = maps.get("META_PROVIDES") or maps.get("meta_provides") or {}
+        for provider, values in sorted(meta_provides.items()):
+            provider_name = str(provider).strip()
+            if not provider_name:
+                continue
+            provider_caps = mapped_provides_by_pkg.setdefault(provider_name, set())
+            for raw in values or []:
+                token = _metadata_name(raw)
+                if token:
+                    provider_caps.add(token)
+                    if provider_name == name:
+                        provides.add(token)
+
         version = str(scal.get("VERSION") or scal.get("version") or "")
         release = str(scal.get("RELEASE") or scal.get("release") or "1")
         arch = str(scal.get("ARCH") or scal.get("arch") or "noarch")
@@ -289,6 +320,7 @@ def run_buildgen(args: Any) -> int:
             "arch": arch,
             "script": _stable_path(script),
             "depends": sorted(dep_names),
+            "provides": sorted(provides),
             "build_output_dir": _stable_path(output_dir / "build" / name),
             "repo_dir": _stable_path(repo_dir),
             "planned_artifact": _stable_path(planned_artifact),
@@ -297,9 +329,34 @@ def run_buildgen(args: Any) -> int:
         deps_by_pkg[name] = set(dep_names)
 
     known = set(meta_by_pkg)
+    provider_index: dict[str, list[str]] = {}
+    for name in sorted(known):
+        provides = set(raw_provides_by_pkg.get(name, set()))
+        provides.update(mapped_provides_by_pkg.get(name, set()))
+        meta_by_pkg[name]["provides"] = sorted(provides)
+        for capability in sorted(provides):
+            provider_index.setdefault(capability, []).append(name)
+    provider_index = {
+        capability: sorted(set(providers))
+        for capability, providers in sorted(provider_index.items())
+    }
+
     for name, deps in deps_by_pkg.items():
-        deps.intersection_update(known)
-        meta_by_pkg[name]["depends"] = sorted(deps)
+        normalized_deps: set[str] = set()
+        for dep in sorted(deps):
+            if dep in known:
+                normalized_deps.add(dep)
+                continue
+            providers = provider_index.get(dep, [])
+            if len(providers) == 1:
+                normalized_deps.add(providers[0])
+            elif len(providers) > 1:
+                raise ValueError(
+                    f"ambiguous provider for dependency {dep!r}: "
+                    + ", ".join(providers)
+                )
+        deps_by_pkg[name] = normalized_deps
+        meta_by_pkg[name]["depends"] = sorted(normalized_deps)
 
     indeg = {k: 0 for k in known}
     rev: dict[str, set[str]] = {k: set() for k in known}

--- a/tests/test_buildgen_buildchroot.py
+++ b/tests/test_buildgen_buildchroot.py
@@ -227,6 +227,50 @@ def test_buildgen_finds_nested_maintainer_mode_layouts(
     assert manifest["packages"][0]["script"] == str(script)
 
 
+def test_buildgen_resolves_virtual_dependencies_from_provides(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    src = tmp_path / "packages"
+    for name in ("consumer", "zlib-ng"):
+        script = src / name / f"{name}.lpmbuild"
+        script.parent.mkdir(parents=True, exist_ok=True)
+        script.write_text("# stub\n", encoding="utf-8")
+
+    from lpm import app as lpm_app
+
+    def fake_capture(path: Path):
+        if path.stem == "consumer":
+            return (
+                {"NAME": "consumer", "VERSION": "1"},
+                {"REQUIRES": ["zlib >= 1", "compression-lib"]},
+                {},
+            )
+        return (
+            {"NAME": "zlib-ng", "VERSION": "1"},
+            {"REQUIRES": [], "PROVIDES": ["compression-lib"]},
+            {"META_PROVIDES": {"zlib-ng": ["zlib"]}},
+        )
+
+    monkeypatch.setattr(lpm_app, "_capture_lpmbuild_metadata", fake_capture)
+
+    out = tmp_path / "out"
+    args = Namespace(
+        root=str(tmp_path / "root"),
+        source=str(src),
+        output_dir=str(out),
+        dry_run=False,
+        verbose=False,
+    )
+
+    assert chroot_helpers.run_buildgen(args) == 0
+
+    manifest = json.loads((out / "build-manifest.json").read_text(encoding="utf-8"))
+    assert manifest["package_order"] == ["zlib-ng", "consumer"]
+    packages = {pkg["name"]: pkg for pkg in manifest["packages"]}
+    assert packages["consumer"]["depends"] == ["zlib-ng"]
+    assert packages["zlib-ng"]["provides"] == ["compression-lib", "zlib"]
+
+
 def test_buildgen_cycle_detection(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
### Motivation
- Ensure `run_buildgen()` can resolve dependencies that refer to virtual capabilities provided via `PROVIDES` arrays and `META_PROVIDES` maps so build ordering and manifests reflect real providers. 
- Make provider resolution deterministic and surface clear errors when a virtual capability is provided by multiple packages.

### Description
- Added a helper ` _metadata_name` that normalizes dependency/provider tokens using `parse_dep_expr` and simple token stripping so versioned expressions yield consistent names. 
- Read `PROVIDES` from arrays and `META_PROVIDES` from maps returned by `lpm_app._capture_lpmbuild_metadata()` and record per-package `provides` in `meta_by_pkg`. 
- Built a `provider_index` mapping each provided capability to a sorted list of package names that provide it and used it to resolve dependency names. 
- Normalized dependency names by first resolving against real package names, then against the `provider_index`, and raised a deterministic `ValueError` on ambiguous providers when multiple packages provide the same capability. 
- Updated manifest package entries to include a `provides` list.

### Testing
- Added `test_buildgen_resolves_virtual_dependencies_from_provides` to `tests/test_buildgen_buildchroot.py` which exercises resolution from both `PROVIDES` and `META_PROVIDES`.
- Ran `pytest -q tests/test_buildgen_buildchroot.py` and all tests passed (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a591dea6c8327a8b14f28816c0fc9)